### PR TITLE
fix dev on app

### DIFF
--- a/apps/site-app/src/app.tsx
+++ b/apps/site-app/src/app.tsx
@@ -35,6 +35,8 @@ import { translations } from './translations';
 
 import { initTracking } from './utils/reactga';
 initTracking();
+import { init } from '@the-coin/logging';
+init('site-landing')
 
 // Create redux store with history
 const store = configureAppStore(undefined);

--- a/libs/contract/src/contract.ts
+++ b/libs/contract/src/contract.ts
@@ -1,6 +1,5 @@
 import { Contract } from 'ethers/contract';
 import { TheCoin } from './types/TheCoin';
-//import { getNetwork } from './network';
 import { getProvider } from './provider';
 
 //
@@ -25,12 +24,14 @@ export const getNetwork = () =>
     ? process.env.SETTINGS === 'staging'
       ? "ropsten"
       : "mainnet"
-    : "development";
+    : process.env.SETTINGS === 'live'
+      ? "development" // In dev:live, connect to local emulator chain
+      : "ropsten";    // In dev, we still connect to ropsten (until we can finish mocking contract)
 
 const getContractAddress = async () => {
-  //const network = getNetwork();
+  const network = getNetwork();
 
-  const deployment = await import(`./deployed/${getNetwork()}.json`);
+  const deployment = await import(`./deployed/${network}.json`);
   if (!deployment) {
     throw new Error('Cannot create contract: missing deployment');
   }

--- a/libs/contract/src/network.ts
+++ b/libs/contract/src/network.ts
@@ -1,8 +1,0 @@
-export type Network = "development"|"ropsten"|"mainnet";
-
-export const getNetwork = () : Network =>
-  process.env.NODE_ENV === 'production'
-    ? process.env.SETTINGS === 'staging'
-      ? "ropsten"
-      : "mainnet"
-    : "development";

--- a/libs/contract/src/provider.ts
+++ b/libs/contract/src/provider.ts
@@ -19,6 +19,11 @@ export const getProvider = () => {
     if (process.env.SETTINGS === 'live') {
       return getDevLiveProvider();
     }
+    else {
+      // For now we use ropsten for dev, at least until we have completed a fully
+      // encapsulated dev environment
+      return new providers.InfuraProvider("ropsten", process.env.INFURA_API_KEY);
+    }
   }
 
   throw new Error(`Unsupported environment: ${process.env.NODE_ENV}:${process.env.SETTINGS}`);

--- a/libs/shared/src/containers/IDX/ceramic.ts
+++ b/libs/shared/src/containers/IDX/ceramic.ts
@@ -6,8 +6,13 @@ declare module globalThis {
   let __ceramic: CeramicApi;
 }
 
-// Public URL: 'https://ceramic-clay.3boxlabs.com'
-const CERAMIC_URL = process.env.CERAMIC_URL || 'http://localhost:7007'
+// TODO: Why isn't this in an environment variable?
+const publicURL = 'https://ceramic-clay.3boxlabs.com'
+const CERAMIC_URL = process.env.NODE_ENV === 'production'
+  ? publicURL
+  : process.env.SETTINGS === 'live'
+    ? 'http://localhost:7007'
+    : publicURL
 
 export function Ceramic(): CeramicApi {
   globalThis.__ceramic = globalThis.__ceramic ?? new HttpCeramic(CERAMIC_URL);

--- a/libs/utils-ts/src/ServiceAddresses.ts
+++ b/libs/utils-ts/src/ServiceAddresses.ts
@@ -28,7 +28,7 @@ export function DevLivePort(service: Service) {
 // indicate the default service should be connected to
 export function ServiceAddress(service: Service) {
   // TODO: production can be either staging or production
-  if (process.env.NODE_ENV === 'production')
+  if (process.env.NODE_ENV === 'production' || process.env.SETTINGS !== 'live')
     return undefined;
   // In debug, we connect locally only
   return 'http://localhost:' + DevLivePort(service);


### PR DESCRIPTION
reverts service connections in 'dev' env back to live processes.  This will allow us to keep developing until the dev env is mocked and can be disconnected entirely from the system 