### PR TITLE
Remove useMemo from sidebar (premature optimization)

### DIFF
--- a/libs/shared/src/containers/PageSidebar/index.tsx
+++ b/libs/shared/src/containers/PageSidebar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Sidebar, Menu, MenuItem, Divider, Icon, SemanticICONS, Header } from "semantic-ui-react";
 import { useSelector } from "react-redux";
 import { NavLink } from "react-router-dom";
@@ -19,19 +19,9 @@ type Props = {
 export const PageSidebar: React.FC<Props> = (props) => {
   const { visible, inverted } = props;
   useSidebar();
-  const appState = useSelector(s => s as ApplicationBaseState);
-  const generators = selectSidebar(appState);
-  const menuItems = useMemo(() => {
-    let items: SidebarMenuItem[] = [];
-
-    Object.entries(generators.generators).forEach(([_, generator]) => {
-      items = generator(items, appState);
-    });
-
-    return buildMenuArray(items);
-  }, [appState, generators])
-
+  const menuItems = useMenuItems();
   const { width } = useWindowDimensions();
+
   return (
       <Sidebar
         as={Menu}
@@ -46,6 +36,18 @@ export const PageSidebar: React.FC<Props> = (props) => {
         {menuItems}
       </Sidebar>
   );
+}
+
+const useMenuItems = () => {
+  let items: SidebarMenuItem[] = [];
+  const appState = useSelector(s => s as ApplicationBaseState);
+  const generators = selectSidebar(appState);
+
+  Object.entries(generators.generators).forEach(([_, generator]) => {
+    items = generator(items, appState);
+  });
+
+  return buildMenuArray(items);
 }
 
 const getAsItem = (item: SidebarMenuItem) => {

--- a/libs/shared/src/containers/PageSidebar/selector.ts
+++ b/libs/shared/src/containers/PageSidebar/selector.ts
@@ -2,5 +2,3 @@ import { ApplicationBaseState } from '../../types';
 import { initialState } from './reducer';
 
 export const selectSidebar = (state: ApplicationBaseState) => state.sidebar || initialState;
-
-export const mapStateToProps = selectSidebar;


### PR DESCRIPTION
Simple fix for the error message sent last night;

Error message was: `Warning: Do not call Hooks inside useEffect(...), useMemo(...), or other...`

The stack trace led directly to Sidebar, and useMemo was the only hook in use here (useSelector is trivial so doesn't count).

Simple test - removing useMemo fixed the error (memoization should never affect functionality, just performance).  Saw an opportunity to refactor the logic out of the react component so moved it into its own hook