### PR TITLE
fixed missing icons.

### DIFF
--- a/libs/site-semantic-theme/src/semantic/theme.config
+++ b/libs/site-semantic-theme/src/semantic/theme.config
@@ -27,7 +27,7 @@
 @divider     : 'thecoin';
 @flag        : 'thecoin';
 @header      : 'thecoin';
-@icon        : 'thecoin';
+@icon        : 'default';
 @image       : 'thecoin';
 @input       : 'thecoin';
 @label       : 'thecoin';

--- a/libs/site-semantic-theme/src/semantic/theme.less
+++ b/libs/site-semantic-theme/src/semantic/theme.less
@@ -71,6 +71,7 @@
 -------------------*/
 
 .loadUIOverrides() {
+  @import (optional) "@{packageFolder}/@{theme}/@{type}s/@{element}.overrides";
   @import (optional) "@{themesFolder}/@{theme}/@{type}s/@{element}.overrides";
   @import (optional) "@{siteFolder}/@{type}s/@{element}.overrides";
 }


### PR DESCRIPTION
The icons were defined in the themes overrides file.  In setting the theme to "thecoin" we lost the original "default" overrides file.

Fixed by setting the theme for checkbox back to default, and ensuring the loader can find the default styling if needed.

There are some other elements (eg checkbox) that have lost default override styling as well.  We will need to discuss what needs to be done for these elements.

![image](https://user-images.githubusercontent.com/4876160/115075098-32e96c80-9ec0-11eb-9034-bef1e24ecd87.png)
