### PR TITLE
refactor all app links to single-source of truth

### DIFF
--- a/apps/site-landing/src/components/AppLinks/CreateAccount.tsx
+++ b/apps/site-landing/src/components/AppLinks/CreateAccount.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ButtonPrimary } from "@thecointech/site-base/components/Buttons";
+import { FormattedMessage } from "react-intl";
+import { SemanticSIZES } from "semantic-ui-react";
+
+const titleButton = {
+  id: 'site.MainNavigation.button,createAccount',
+  defaultMessage: 'Create Account',
+  description: 'Button to create account in app'
+};
+
+export const CreateAccountButton = ({ size }: { size?: SemanticSIZES }) =>
+  <ButtonPrimary as={"a"} href={`${process.env.URL_SITE_APP}/#/addAccount`} size={size}>
+    <FormattedMessage {...titleButton} />
+  </ButtonPrimary>
+

--- a/apps/site-landing/src/components/AppLinks/Login.tsx
+++ b/apps/site-landing/src/components/AppLinks/Login.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import styles from './styles.module.less';
+
+const loginLink = {
+  id: "site.MainNavigation.loginLink",
+  defaultMessage: "LOG IN",
+  description: "Link to app login page"
+};
+
+export const LoginLink = () =>
+  <a href={process.env.URL_SITE_APP} className={styles.loginLink}>
+    <FormattedMessage {...loginLink} />
+  </a>

--- a/apps/site-landing/src/components/AppLinks/styles.module.less
+++ b/apps/site-landing/src/components/AppLinks/styles.module.less
@@ -1,0 +1,6 @@
+
+.loginLink{
+  text-decoration: uppercase;
+  border-bottom: none;
+  padding-bottom: 0;
+}

--- a/apps/site-landing/src/containers/CreateAccountBanner/index.tsx
+++ b/apps/site-landing/src/containers/CreateAccountBanner/index.tsx
@@ -5,7 +5,7 @@ import illustrationPeople from './images/illust_grow.svg';
 import illustrationPlant from './images/illust_flowers.svg';
 
 import styles from './styles.module.less';
-import { ButtonPrimary } from '@thecointech/site-base/components/Buttons';
+import { CreateAccountButton } from 'components/AppLinks/CreateAccount';
 
 export enum TypeCreateAccountBanner {
     People,
@@ -20,10 +20,6 @@ const title = { id:"site.createAccountBanner.title",
                 defaultMessage:"The benefits of a chequing, savings, and investing account all in one!",
                 description:"The benefits of a chequing, savings, and investing account all in one!"};
 
-const buttonCreate = { id:"site.createAccountBanner.button",
-                        defaultMessage:"Create Account",
-                        description:"Create Account button for the create account banner for interior pages"};
-
 export const CreateAccountBanner = (props: Props) => {
 
     let illustration = illustrationPlant;
@@ -37,9 +33,7 @@ export const CreateAccountBanner = (props: Props) => {
                     <Header as='h3'>
                         <FormattedMessage {...title} />
                     </Header>
-                    <ButtonPrimary as={"a"} href={process.env.URL_ACCOUNT_CREATE} size='large' >
-                        <FormattedMessage {...buttonCreate} />
-                    </ButtonPrimary>
+                    <CreateAccountButton size='large' />
                 </Grid.Column>
             </Grid.Row>
             <Grid.Row>

--- a/apps/site-landing/src/containers/HomePage/createAccountSmall/index.tsx
+++ b/apps/site-landing/src/containers/HomePage/createAccountSmall/index.tsx
@@ -2,16 +2,11 @@ import * as React from 'react';
 import { Grid, Header } from 'semantic-ui-react';
 import { FormattedMessage } from 'react-intl';
 import styles from './styles.module.less';
-import { ButtonPrimary } from '@thecointech/site-base/components/Buttons';
-
+import { CreateAccountButton } from 'components/AppLinks/CreateAccount';
 
 const title = { id:"site.homepage.createAccountSmall.title",
                 defaultMessage:"TheCoin is a revolutionary new kind of account.",
                 description:"Title / content for the small create account banner"};
-const button = {  id:"site.homepage.createAccountSmall.button",
-                  defaultMessage:"Create Account",
-                  description:"Create Account button for the small create account banner for the home pages"};
-
 
 export const CreateAccountSmall = () => {
 
@@ -26,9 +21,7 @@ export const CreateAccountSmall = () => {
         </Grid.Row>
         <Grid.Row>
           <Grid.Column>
-            <ButtonPrimary as={"a"} href={process.env.URL_ACCOUNT_CREATE} size='large' >
-              <FormattedMessage {...button} />
-            </ButtonPrimary>
+            <CreateAccountButton size="large" />
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/apps/site-landing/src/containers/MainNavigation/MainNavigationGreaterThanMobile/index.tsx
+++ b/apps/site-landing/src/containers/MainNavigation/MainNavigationGreaterThanMobile/index.tsx
@@ -3,13 +3,11 @@ import { Menu, Container } from 'semantic-ui-react';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import HeaderLink from '@thecointech/site-base/components/HeaderLink';
-
 import {LanguageSwitcher} from '@thecointech/site-base/containers/LanguageSwitcher';
-
 import Logo from './logoAndName.svg';
 import styles from './styles.module.less';
-import sharedStyles from '../styles.module.less';
-import { ButtonPrimary } from '@thecointech/site-base/components/Buttons';
+import { CreateAccountButton } from 'components/AppLinks/CreateAccount';
+import { LoginLink } from 'components/AppLinks/Login';
 
 const home = { id:"site.MainNavigation.home",
                 defaultMessage:"Home",
@@ -23,10 +21,6 @@ const wedomore = {  id:"site.MainNavigation.wedomore",
 const yourbenefits = {  id:"site.MainNavigation.yourbenefits",
                     defaultMessage:"Your benefits",
                     description:"Title for the Your benefits entry in the menu"};
-const titleButton = { id: 'site.MainNavigation.button,createAccount', defaultMessage:'Create Account'};
-const loginLink = {  id:"site.MainNavigation.loginLink",
-                    defaultMessage:"LOG IN",
-                    description:"Title for the Login entry in the menu"};
 
 // TODO: Fix Login button
 export const MainNavigationGreaterThanMobile = () => {
@@ -53,14 +47,10 @@ export const MainNavigationGreaterThanMobile = () => {
                 </HeaderLink>
                 <Menu.Menu position='right'>
                   <Menu.Item>
-                    <a href={process.env.URL_ACCOUNT_LOGIN} className={sharedStyles.loginLink}>
-                      <FormattedMessage {...loginLink} />
-                    </a>
+                    <LoginLink />
                   </Menu.Item>
                   <Menu.Item>
-                    <ButtonPrimary as={"a"} href={process.env.URL_ACCOUNT_CREATE} >
-                        <FormattedMessage {...titleButton} />
-                    </ButtonPrimary>
+                    <CreateAccountButton />
                   </Menu.Item>
                   <Menu.Item>
                     <LanguageSwitcher />

--- a/apps/site-landing/src/containers/MainNavigation/MainNavigationMobile/index.tsx
+++ b/apps/site-landing/src/containers/MainNavigation/MainNavigationMobile/index.tsx
@@ -4,7 +4,7 @@ import {LanguageSwitcher} from '@thecointech/site-base/containers/LanguageSwitch
 import { FormattedMessage } from 'react-intl';
 import Logo from './logo.svg';
 import { Link, NavLink } from 'react-router-dom';
-import sharedStyles from '../styles.module.less';
+import { LoginLink } from 'components/AppLinks/Login';
 import styles from './styles.module.less';
 
 const home = { id:"site.MainNavigation.home",
@@ -19,9 +19,7 @@ const wedomore = {  id:"site.MainNavigation.wedomore",
 const yourbenefits = {  id:"site.MainNavigation.yourbenefits",
                     defaultMessage:"Your benefits",
                     description:"Title for the Your benefits entry in the menu"};
-const loginLink = {  id:"site.MainNavigation.loginLink",
-                    defaultMessage:"LOG IN",
-                    description:"Title for the Login entry in the menu"};
+
 
 export const MainNavigationMobile = () => {
   return (
@@ -35,9 +33,7 @@ export const MainNavigationMobile = () => {
               </Menu.Menu>
               <Menu.Menu position='right'>
                 <Menu.Item>
-                  <a href={process.env.URL_ACCOUNT_LOGIN} className={sharedStyles.loginLink}>
-                    <FormattedMessage {...loginLink} />
-                  </a>
+                  <LoginLink />
                 </Menu.Item>
                 <Menu.Item>
                   <LanguageSwitcher />

--- a/apps/site-landing/src/containers/MainNavigation/styles.module.less
+++ b/apps/site-landing/src/containers/MainNavigation/styles.module.less
@@ -4,12 +4,6 @@
     height: 60px;
     margin-bottom: 50px;
     .ui.secondary.pointing.menu{
-        border-bottom: none;   
+        border-bottom: none;
     }
-}
-
-.loginLink{
-    text-decoration: uppercase;
-    border-bottom: none;
-    padding-bottom: 0;
 }

--- a/libs/site-base/internal/webpack/webpack.base.babel.js
+++ b/libs/site-base/internal/webpack/webpack.base.babel.js
@@ -143,9 +143,6 @@ module.exports = options => ({
       URL_SERVICE_RATES: process.env.URL_SERVICE_RATES,
 
       // convenience defines
-      URL_ACCOUNT_CREATE: `${process.env.URL_SITE_APP}/#/addAccount`,
-      URL_ACCOUNT_LOGIN: process.env.URL_SITE_APP,
-
       DEPLOY_NETWORK: process.env.DEPLOY_NETWORK,
       DEPLOY_NETWORK_PORT: process.env.DEPLOY_NETWORK_PORT,
     }),


### PR DESCRIPTION
I chose those buttons to refactor into single-source-of-truth because it was easy, but also because I already had to make edits across all buttons a few times.  As links between the websites, they are more likely to need updating etc, and this will make that easier.

Also, we remove a few duplicate translations and reduce complexity in some of the larger components.

Tested in dev:live