### PR TITLE
re-enable concurrency on CI test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "clean:ceramic": "rimraf ~/.ceramic && ~/.jsipfs",
     "clean:apis": "git clean -qfdx ./apis",
     "test": "lerna run test",
-    "test:ci": "lerna run test --stream -- --ci --forceExit",
+    "test:ci": "lerna run test -- --ci --forceExit",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "clean:ceramic": "rimraf ~/.ceramic && ~/.jsipfs",
     "clean:apis": "git clean -qfdx ./apis",
     "test": "lerna run test",
-    "test:ci": "lerna run test --stream --concurrency 1 -- --ci --forceExit",
+    "test:ci": "lerna run test --stream -- --ci --forceExit",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
Our CI test is working, but is currently restricted (from efforts to figure out what was going wrong).

The error was likely caused by Date issues in utilities, so this PR removes those restrictions again.