### PR TITLE
Fix restore 'goto' step in loading saved accounts

### DIFF
--- a/libs/site-base/src/containers/AddAccount/Storage/GDrive/RestoreList.tsx
+++ b/libs/site-base/src/containers/AddAccount/Storage/GDrive/RestoreList.tsx
@@ -27,7 +27,7 @@ type Props = {
 }
 export const RestoreList = ({url}: Props) => {
 
-  const [wallets, setWallets] = useState(undefined as (LoadingWallet[]) | undefined)
+  const [wallets, setWallets] = useState(undefined as (GoogleWalletItem[]) | undefined)
   const [redirect, setRedirect] = useState('');
   const accountsApi = AccountMap.useApi();
   const accounts = AccountMap.useAsArray();
@@ -39,8 +39,7 @@ export const RestoreList = ({url}: Props) => {
     if (token) {
       const api = GetSecureApi();
       api.googleRetrieve(clientUri, { token })
-        .then(r => parseWallets(r.data.wallets, accounts))
-        .then(r => setWallets(r))
+        .then(({data}) => setWallets(data.wallets))
         .catch(log.error)
     }
   }, [token]);
@@ -72,8 +71,8 @@ export const RestoreList = ({url}: Props) => {
       : (
         <List divided relaxed>
           {
-            wallets.map(wallet => {
-              return (
+            parseWallets(wallets, accounts)
+              .map(wallet => (
                 <List.Item key={wallet.id}>
                   <List.Content className={styles.accountRow}>
                     {wallet.name}
@@ -88,7 +87,7 @@ export const RestoreList = ({url}: Props) => {
                   </List.Content>
                 </List.Item>
               )
-            })
+            )
           }
         </List>
       )


### PR DESCRIPTION
Initial branch for feature "Restore Accounts"

The functionality is already more-or-less complete.  However past that the page looks pretty pants.

![image](https://user-images.githubusercontent.com/4876160/127739333-9e4a3b04-9e02-41e6-b9b4-40bade36a49f.png)

The full page running in context looks like this:

https://user-images.githubusercontent.com/4876160/127738916-9795b280-9aff-4806-9eae-a6cb4cb27ed7.mp4


