### PR TITLE
Fix/history repeat load

### DIFF
--- a/libs/tx-blockchain/src/fetch.test.ts
+++ b/libs/tx-blockchain/src/fetch.test.ts
@@ -8,7 +8,7 @@ import { describe, IsManualRun } from '@thecointech/jestutils';
 jest.unmock('@thecointech/contract');
 
 async function fetchAndTestBalance(adress: string, contract: TheCoin) {
-  const history = await loadAndMergeHistory(adress, 0, contract, []);
+  const history = await loadAndMergeHistory(adress, 0, contract);
   const balance = await contract.balanceOf(adress) as BigNumber;
   validateHistory(history, balance);
   return history;

--- a/libs/tx-blockchain/src/fetch.ts
+++ b/libs/tx-blockchain/src/fetch.ts
@@ -1,29 +1,15 @@
-
-
-///////////////////////////////////////////////////////////////////////////////////
-
 import { Transaction } from "./types";
 import { TheCoin } from '@thecointech/contract';
 import { EventFilter, providers, BigNumber } from "ethers";
 import { toHuman } from "@thecointech/utilities";
 import { DateTime } from "luxon";
-
+import { log } from '@thecointech/logging';
 
 // Load account history and merge with local
 export function mergeTransactions(history: Transaction[], moreHistory: Transaction[]) {
   const mergedHistory = history.concat(moreHistory);
   mergedHistory.sort((tx1, tx2) => tx1.date.valueOf() - tx2.date.valueOf());
   return mergedHistory;
-
-  // NOTE - this old implementation gave us bad results on sending tx's to yourself, but
-  // I don't remember why it was implemetned this way in the first place.
-
-  // const uniqueItems = moreHistory.filter((tx) => !history.find((htx) => htx.txHash === tx.txHash))
-  // if (uniqueItems.length) {
-  //   history = history.concat(uniqueItems);
-  //   history.sort((tx1, tx2) => tx1.date.valueOf() - tx2.date.valueOf())
-  // }
-  // return history;
 }
 
 async function addAdditionalInfo(transaction: Transaction, toWallet: boolean, contract: TheCoin): Promise<boolean> {
@@ -102,66 +88,20 @@ async function readAndMergeTransfers(account: string, to: boolean, fromBlock: nu
   return mergeTransactions(history, txs);
 }
 
-//async function  purchaseToTransaction(account: string, ethersLog: Log, contract: Contract): Promise<Transaction> {
-//   const res = contract.interface.parseLog(ethersLog);
-//   const {purchaser, amount, balance, timestamp} = res.values;
-//   if (account != purchaser)
-//     return null;
-//   return {
-//     txHash: ethersLog.transactionHash,
-//     date: new Date(timestamp.toNumber() * 1000),
-//     change: amount.toNumber(),
-//     logEntry: `Purchase: ${amount.toNumber()}`,
-//     balance: balance.toNumber()
-//   }
-// }
-
-//async function  readAndMergePurchases(account: string, fromBlock: number, contract: Contract, history: Transaction[]) {
-//   // construct filter to get tx either from or to
-//   let filter: any = contract.filters.Purchase();
-//   filter.fromBlock = fromBlock || 0;
-//   // Retrieve logs
-//   const txLogs = await contract.provider.getLogs(filter)
-//   // Convert logs to our transactions
-//   let txs: Transaction[] = [];
-//   for (let i = 0; i < txLogs.length; i++) {
-//     const tx = await purchaseToTransaction(account, txLogs[i], contract);
-//     if (tx)
-//       txs.push(tx);
-//   }
-//   // merge and remove duplicates for complete array
-//   return mergeTransactions(history, txs);
-// }
-
-export async function loadAndMergeHistory(address: string, fromBlock: number, contract: TheCoin, history: Transaction[]) {
+export async function loadAndMergeHistory(address: string, fromBlock: number, contract: TheCoin) {
   try {
-    //history = await readAndMergePurchases(address, fromBlock, contract, history);
+    let history: Transaction[] = [];
     history = await readAndMergeTransfers(address, true, fromBlock, contract, history);
     history = await readAndMergeTransfers(address, false, fromBlock, contract, history);
+    return history;
   }
   catch (err) {
-    console.error(err);
+    log.error(err);
   }
-  return history;
+  return [];
 }
 
 export function calculateTxBalances(currentBalance: BigNumber, history: Transaction[]) {
-  //let lastBalance = currentBalance;
-  // history.reverse().forEach(tx => {
-  //   // if (tx.balance >= 0) {
-  //   //   if (lastBalance != tx.balance)
-  //   //     console.error('Invalid balance detected: ', lastBalance, history, tx);
-  //   //   lastBalance = tx.balance;
-  //   // }
-  //   // else {
-  //     // tx balance records the balance after the action
-  //     // is finished (so the last action records current balance)
-
-  //   //}
-  //   tx.balance = lastBalance.toNumber();
-  //   lastBalance = lastBalance.sub(tx.change);
-  // });
-
   // history is sorted - oldest first.
   let balance = currentBalance;
   for (let i = history.length - 1; i >= 0; i--) {

--- a/libs/tx-blockchain/src/thecoin.ts
+++ b/libs/tx-blockchain/src/thecoin.ts
@@ -1,7 +1,6 @@
 import { GetContract, TheCoin } from "@thecointech/contract";
 import { BigNumber } from "ethers";
-import { loadAndMergeHistory, calculateTxBalances } from "./fetch";
-import { Transaction } from "./types";
+import { loadAndMergeHistory, calculateTxBalances, mergeTransactions } from "./fetch";
 
 
 // we have 2 accounts (in & out) for the same entity
@@ -11,9 +10,9 @@ export const cadbrokerIn = "0x38de1b6515663dbe145cc54179addcb963bb606a";
 export async function fetchCoinHistory(contract?: TheCoin) {
   const tc = contract ?? await GetContract();
 
-  let history : Transaction[] = [];
-  history = await loadAndMergeHistory(cadbrokerOut, 0, tc, history);
-  history = await loadAndMergeHistory(cadbrokerIn, 0, tc, history);
+  const historyOut = await loadAndMergeHistory(cadbrokerOut, 0, tc);
+  const historyIn = await loadAndMergeHistory(cadbrokerIn, 0, tc);
+  const history = mergeTransactions(historyOut, historyIn);
 
   const balanceOut = await tc.balanceOf(cadbrokerOut) as BigNumber;
   const balanceIn = await tc.balanceOf(cadbrokerIn) as BigNumber;


### PR DESCRIPTION
When navigating pages, the history pane will update transactions.  The code would re-calculate all balances, but this modified state in redux, (is disallowed) which then caused an exception.