### PR TITLE
Fix infinte loop on gen account

### DIFF
--- a/libs/shared/src/components/UX/Input/index.tsx
+++ b/libs/shared/src/components/UX/Input/index.tsx
@@ -46,7 +46,7 @@ export const UxInput = (props: BaseProps) => {
     else {
       localChange(value);
     }
-  }, [forceValidate, onValidate])
+  }, [forceValidate])
 
   // Reset to default value either if requested, or if defaultValue changes
   useEffect(() => {

--- a/libs/shared/src/containers/Account/reducer.ts
+++ b/libs/shared/src/containers/Account/reducer.ts
@@ -47,7 +47,6 @@ function AccountReducer(address: string, initialState: AccountState) {
 
     ///////////////////////////////////////////////////////////////////////////////////
     // Save/load private details
-
     *getIDX() {
       let idx = this.state.idx;
       if (!idx) {
@@ -165,26 +164,19 @@ function AccountReducer(address: string, initialState: AccountState) {
           undefined :
           (per: number) => {
             const percent = Math.floor(per * 100);
-            if (!callback(percent)) {
-              throw ("Operation cancelled");
-            }
+            return !callback(percent);
           }
         const decrypted = yield call(Wallet.fromEncryptedJson, JSON.stringify(signer), password, cb);
         // Ensure callback is called with 100% result so caller knows we are done
-        console.log("Account decrypted successfully");
+        log.trace("Account decrypted successfully");
         if (callback) {
           callback(1);
         }
-
-        // Connect to the contract
-        //const contract = yield call(ConnectContract, decrypted);
-        // Store the live data
-        //yield this.storeValues({contract, signer: decrypted})
-        // Now, update balance
+        // Store the result
         yield this.sendValues(this.actions.setSigner, [decrypted]);
       }
-      catch (error) {
-        console.error(error);
+      catch (error: any) {
+        log.warn(error.message);
         if (callback)
           callback(-1);
       }

--- a/libs/shared/src/containers/Login/index.tsx
+++ b/libs/shared/src/containers/Login/index.tsx
@@ -109,6 +109,9 @@ export const Login = (props: Props) => {
       setPercentComplete(-1);
       if (!__cancel) {
         setValidateFn(() => badPwdValid(password!));
+        // Force validation update by toggling forceValidate
+        setForceValidate(v => !v);
+        setForceValidate(v => !v);
       }
       return false;
     }


### PR DESCRIPTION
When creating an account, it was possible to overflow the stack if submitting before the validation of any of the inputs was complete