### PR TITLE
fix/firestoreDocChange

### DIFF
--- a/libs/broker-db/src/transaction/index.ts
+++ b/libs/broker-db/src/transaction/index.ts
@@ -41,7 +41,10 @@ export function storeTransition(action: DocumentReference<AnyActionData>, transi
 }
 
 ////////////////////////////////////////////////////////////////////
-export const getActionDoc = <Type extends ActionType>(address: string, type: Type, id?: string) => userActionCollection(address, type).doc(id);
+export const getActionDoc = <Type extends ActionType>(address: string, type: Type, id?: string) =>
+  id
+    ? userActionCollection(address, type).doc(id)
+    : userActionCollection(address, type).doc();
 
 //
 // Return action data for the action by type/firestore id


### PR DESCRIPTION
It seems Firestore doc path changed with recent point update.

Now passing an explicit undefined to `doc()` throws, so we explicitly test the existence of the ID before passing it in