### PR TITLE
Do not getSigner on production builds

### DIFF
--- a/libs/setenv/src/index.ts
+++ b/libs/setenv/src/index.ts
@@ -14,7 +14,6 @@ export function getEnvFiles(cfgName?: string, onlyPublic?: boolean) {
   // without our environment variables.  (This is mostly to avoid
   // looking for files when running on a production machine.)
   const systemFolder = process.env.THECOIN_ENVIRONMENTS;
-  if (!systemFolder) return files;
 
   const envName = cfgName || process.env.CONFIG_NAME || (
     process.env.NODE_ENV == "production"
@@ -36,9 +35,7 @@ export function getEnvFiles(cfgName?: string, onlyPublic?: boolean) {
   }
 
   // None found, throw
-  if (files.length == 0) {
-    throw new Error(`Missing cfg files for: ${cfgName} (${repoUrl})`);
-  }
+  if (files.length == 0) return files;
 
   // Beta versions share a lot with non-beta environments, so we merge them together
   if (envName.endsWith("beta")) {
@@ -54,7 +51,7 @@ export function getEnvVars(cfgName?: string, onlyPublic?: boolean) : Record<stri
     .map(file => readFileSync(file))
     .reduce((acc, contents) => ({
     ...de.parse(contents),
-    ...acc, // later files have lower priority, do not overwrite existing balues
+    ...acc, // later files have lower priority, do not overwrite existing values
   }), {
     LOG_NAME,
   });

--- a/libs/setenv/src/index.ts
+++ b/libs/setenv/src/index.ts
@@ -10,18 +10,15 @@ const LOG_NAME = basename(projectRoot);
 export function getEnvFiles(cfgName?: string, onlyPublic?: boolean) {
   const files : URL[] = [];
 
-  // If this is not a development machine, just bail - we can't run
-  // without our environment variables.  (This is mostly to avoid
-  // looking for files when running on a production machine.)
-  const systemFolder = process.env.THECOIN_ENVIRONMENTS;
-
   const envName = cfgName || process.env.CONFIG_NAME || (
     process.env.NODE_ENV == "production"
       ? "prod"
       : "development"
   );
+
   // Does the user have files on the system
   if (!onlyPublic) {
+    const systemFolder = process.env.THECOIN_ENVIRONMENTS;
     const systemFile = new URL(`${envName}.private.env`, `file://${systemFolder}/`)
     if (existsSync(systemFile)) {
       files.push(systemFile);

--- a/libs/site-base/internal/webpack/webpack.signers.mjs
+++ b/libs/site-base/internal/webpack/webpack.signers.mjs
@@ -13,6 +13,7 @@ async function getAddresses() {
   }
 }
 
+console.log("WALLET_BrokerCAD_ADDRESS: ", JSON.stringify(getEnvVars(), null, 2));
 export default {
   plugins: [
     new webpack.DefinePlugin(

--- a/libs/site-base/internal/webpack/webpack.signers.mjs
+++ b/libs/site-base/internal/webpack/webpack.signers.mjs
@@ -1,5 +1,6 @@
 import webpack from 'webpack';
 import { getSigner } from '@thecointech/signers';
+import { getEnvVars } from '@thecointech/setenv';
 
 // Now, we can use top-level await to fetch our addresses directly
 // (this allows us to correctly inject addresses even for dynamic environments like dev:live)
@@ -20,7 +21,7 @@ export default {
       // the live signer and get it's address directly.
       // We can't do this every time because a production address
       // may not always exist
-      process.env.WALLET_BrokerCAD_ADDRESS
+      getEnvVars().WALLET_BrokerCAD_ADDRESS
         ? {}
         : await getAddresses()
     ),


### PR DESCRIPTION
We are calling getSigner to get an address that should be in our env vars.