### PR TITLE
Skip maven search on build

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -42,7 +42,10 @@ jobs:
 
     - name: Build
       env:
-         # Fix OOM in build admin
+        # Bypass maven search:
+        # https://github.com/thecointech/thecoin/issues/691
+        OPENAPI_GENERATOR_CLI_SEARCH_URL: DEFAULT
+        # Fix OOM in build admin
         NODE_OPTIONS: "--max-old-space-size=6144"
       run: yarn build
 


### PR DESCRIPTION
Potentially resolves https://github.com/thecointech/thecoin/issues/691

However, we can't test this works because maven is back up again