### PR TITLE
Publish/remove beta packages

### DIFF
--- a/.github/workflows/action-publish-packages.yml
+++ b/.github/workflows/action-publish-packages.yml
@@ -56,13 +56,8 @@ jobs:
         run: |
           if [ "${{ vars.CONFIG_NAME }}" = "prodtest" ]; then
             yarn lerna version --conventional-commits --include-merged-tags --conventional-prerelease --preid test --yes
-          elif [ "${{ vars.CONFIG_NAME }}" = "prodbeta" ]; then
-            yarn lerna version --conventional-commits --include-merged-tags --conventional-prerelease --preid beta --yes
-          elif [ "${{ vars.CONFIG_NAME }}" = "prod" ]; then
-            yarn lerna version --conventional-commits --include-merged-tags --conventional-graduate --yes
           else
-            echo "::error::Unknown environment: ${{ vars.CONFIG_NAME }}"
-            exit 1
+            yarn lerna version --conventional-commits --include-merged-tags --conventional-graduate --yes
           fi
           yarn lerna publish from-git --yes
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/the-coin
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/the-coin

--- a/apps/admin/CHANGELOG.md
+++ b/apps/admin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package thecoin-admin
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package thecoin-admin

--- a/apps/broker-service/CHANGELOG.md
+++ b/apps/broker-service/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/broker-service
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/broker-service

--- a/apps/harvester/CHANGELOG.md
+++ b/apps/harvester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package harvester
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package harvester

--- a/apps/nft-service/CHANGELOG.md
+++ b/apps/nft-service/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/nft-service
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/nft-service

--- a/apps/rates-service/CHANGELOG.md
+++ b/apps/rates-service/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/rates-service
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/rates-service

--- a/apps/site-app/CHANGELOG.md
+++ b/apps/site-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/site-app
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/site-app

--- a/apps/site-fake-deposit/CHANGELOG.md
+++ b/apps/site-fake-deposit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/site-test-deposit
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/site-test-deposit

--- a/apps/site-landing/CHANGELOG.md
+++ b/apps/site-landing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/site-landing
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/site-landing

--- a/apps/site-nft/CHANGELOG.md
+++ b/apps/site-nft/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/site-nft
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/site-nft

--- a/apps/tx-processor/CHANGELOG.md
+++ b/apps/tx-processor/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-processor
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-processor

--- a/libs/IDX/CHANGELOG.md
+++ b/libs/IDX/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/idx
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/idx

--- a/libs/account/CHANGELOG.md
+++ b/libs/account/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/account
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/account

--- a/libs/blockpass/CHANGELOG.md
+++ b/libs/blockpass/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/blockpass
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/blockpass

--- a/libs/broker-db/CHANGELOG.md
+++ b/libs/broker-db/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/broker-db
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/broker-db

--- a/libs/contract-base/CHANGELOG.md
+++ b/libs/contract-base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-base
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-base

--- a/libs/contract-core/CHANGELOG.md
+++ b/libs/contract-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-core
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-core

--- a/libs/contract-nft/CHANGELOG.md
+++ b/libs/contract-nft/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-nft
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-nft

--- a/libs/contract-oracle/CHANGELOG.md
+++ b/libs/contract-oracle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-oracle
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-oracle

--- a/libs/contract-plugin-converter/CHANGELOG.md
+++ b/libs/contract-plugin-converter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-plugin-converter
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-plugin-converter

--- a/libs/contract-plugin-roundnumber/CHANGELOG.md
+++ b/libs/contract-plugin-roundnumber/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-plugin-roundnumber
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-plugin-roundnumber

--- a/libs/contract-plugin-shockabsorber/CHANGELOG.md
+++ b/libs/contract-plugin-shockabsorber/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-plugin-shockabsorber
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-plugin-shockabsorber

--- a/libs/contract-plugins/CHANGELOG.md
+++ b/libs/contract-plugins/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-plugins
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-plugins

--- a/libs/contract-tools/CHANGELOG.md
+++ b/libs/contract-tools/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/contract-tools
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/contract-tools

--- a/libs/electron-utils/CHANGELOG.md
+++ b/libs/electron-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/electron-utils
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/electron-utils

--- a/libs/email-fake-deposit/CHANGELOG.md
+++ b/libs/email-fake-deposit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/email-fake-deposit
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/email-fake-deposit

--- a/libs/email/CHANGELOG.md
+++ b/libs/email/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/email
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/email

--- a/libs/ethers-provider/CHANGELOG.md
+++ b/libs/ethers-provider/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/ethers-provider
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/ethers-provider

--- a/libs/firestore/CHANGELOG.md
+++ b/libs/firestore/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/firestore
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/firestore

--- a/libs/market-status/CHANGELOG.md
+++ b/libs/market-status/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/market-status
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/market-status

--- a/libs/rbcapi/CHANGELOG.md
+++ b/libs/rbcapi/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/rbcapi
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/rbcapi

--- a/libs/scraper-agent/CHANGELOG.md
+++ b/libs/scraper-agent/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/scraper-agent
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/scraper-agent

--- a/libs/secrets/CHANGELOG.md
+++ b/libs/secrets/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/secrets
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/secrets

--- a/libs/shared/CHANGELOG.md
+++ b/libs/shared/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/shared
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/shared

--- a/libs/signers/CHANGELOG.md
+++ b/libs/signers/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/signers
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/signers

--- a/libs/site-base/CHANGELOG.md
+++ b/libs/site-base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/site-base
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/site-base

--- a/libs/storybookutils/CHANGELOG.md
+++ b/libs/storybookutils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/storybookutils
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/storybookutils

--- a/libs/tx-bill/CHANGELOG.md
+++ b/libs/tx-bill/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-bill
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-bill

--- a/libs/tx-blockchain/CHANGELOG.md
+++ b/libs/tx-blockchain/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-blockchain
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-blockchain

--- a/libs/tx-deposit/CHANGELOG.md
+++ b/libs/tx-deposit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-deposit
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-deposit

--- a/libs/tx-etransfer/CHANGELOG.md
+++ b/libs/tx-etransfer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-etransfer
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-etransfer

--- a/libs/tx-gmail/CHANGELOG.md
+++ b/libs/tx-gmail/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-gmail
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-gmail

--- a/libs/tx-plugins/CHANGELOG.md
+++ b/libs/tx-plugins/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-plugins
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-plugins

--- a/libs/tx-reconciliation/CHANGELOG.md
+++ b/libs/tx-reconciliation/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-reconciliation
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-reconciliation

--- a/libs/tx-statemachine/CHANGELOG.md
+++ b/libs/tx-statemachine/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/tx-statemachine
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/tx-statemachine

--- a/libs/utils-ts/CHANGELOG.md
+++ b/libs/utils-ts/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @thecointech/utilities
+
+
+
+
+
 ## [0.3.3-test.1](https://github.com/thecointech/thecoin/compare/v0.3.3-test.0...v0.3.3-test.1) (2025-04-16)
 
 **Note:** Version bump only for package @thecointech/utilities


### PR DESCRIPTION
when no changes are detected it appears that lerna does not bump versions and tries to publish the same version again.

Try promoting test to beta, and we'll just merge prod & beta as they are all live at that point anyway