### PR TITLE
standardize BitWarden variable names, always pull secrets from BitWarden

### DIFF
--- a/.github/workflows/action-publish-sites.yml
+++ b/.github/workflows/action-publish-sites.yml
@@ -67,7 +67,8 @@ jobs:
         working-directory: ./apps/site-app
         env:
           CONFIG_NAME: ${{ inputs.CONFIG_NAME }}
-          PolygonscanApiKey: ${{ secrets.POLYGONSCAN_API_KEY }}
+          BWS_ACCESS_TOKEN: ${{ secrets.BWS_ACCESS_TOKEN }}
+          BWS_ORGANIZATION_ID: ${{ secrets.BWS_ORGANIZATION_ID }}
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/apps/vqa-service/src/vqa_secrets.py
+++ b/apps/vqa-service/src/vqa_secrets.py
@@ -50,6 +50,6 @@ def get_secrets() -> dict[str, str]:
       )
       # Attempt to authenticate with the Secrets Manager Access Token
       client.auth().login_access_token(env["BWS_ACCESS_TOKEN"], env["BWS_STATE_FILE"])
-      secrets = client.secrets().sync(env['ORGANIZATION_ID'], None).data.secrets
+      secrets = client.secrets().sync(env['BWS_ORGANIZATION_ID'], None).data.secrets
       _secrets = dict((s.key, s.value) for s in secrets)
   return _secrets

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -6,6 +6,8 @@ Our secrets are mostly stored on bitwarden, however a few GAE-specific
 secrets are stored in the Google Secrets manager.  Both versions are
 accessed through the secrets package.
 
+Less sensitive secrets are stored in Bitwardens `{config-name}-online` projects.  These can be read by online services & github deployments.
+
 ### Electron: Access to BrokerDB firestore
 
 Go to firebase => project overview => * => project settings => General => Your Apps

--- a/libs/secrets/src/node/bitwarden/client.test.ts
+++ b/libs/secrets/src/node/bitwarden/client.test.ts
@@ -22,7 +22,7 @@ jest.unstable_mockModule('@bitwarden/sdk-napi', () => ({
 }));
 jest.unstable_mockModule('fs', () => ({
   existsSync: jest.fn<any>().mockReturnValue(true),
-  readFileSync: jest.fn<any>().mockReturnValue(`ORGANIZATION_ID=${expectedOrgId}\nBWS_ACCESS_TOKEN=${expectedAccessToken}\nBWS_STATE_FILE=${expectedStateFile}`)
+  readFileSync: jest.fn<any>().mockReturnValue(`BWS_ORGANIZATION_ID=${expectedOrgId}\nBWS_ACCESS_TOKEN=${expectedAccessToken}\nBWS_STATE_FILE=${expectedStateFile}`)
 }));
 
 const { getClient } = await import('./client');

--- a/libs/secrets/src/node/bitwarden/client.ts
+++ b/libs/secrets/src/node/bitwarden/client.ts
@@ -56,11 +56,11 @@ export async function createClient(config?: ConfigType) {
 
 async function getBwsVars(config?: ConfigType) {
   // Is the key an environment variable?
-  if (process.env.BWS_ACCESS_TOKEN && process.env.ORGANIZATION_ID) {
+  if (process.env.BWS_ACCESS_TOKEN && process.env.BWS_ORGANIZATION_ID) {
     return {
       accessToken: process.env.BWS_ACCESS_TOKEN,
       stateFile: process.env.BWS_STATE_FILE,
-      organizationId: process.env.ORGANIZATION_ID,
+      organizationId: process.env.BWS_ORGANIZATION_ID,
     };
   }
 
@@ -87,6 +87,6 @@ async function getBwsVars(config?: ConfigType) {
   return {
     accessToken: parsed.BWS_ACCESS_TOKEN,
     stateFile: parsed.BWS_STATE_FILE,
-    organizationId: parsed.ORGANIZATION_ID,
+    organizationId: parsed.BWS_ORGANIZATION_ID,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal configuration for secret management to use standardized environment variable naming conventions

* **Documentation**
  * Clarified documentation regarding secret storage locations and access patterns for deployment systems
<!-- end of auto-generated comment: release notes by coderabbit.ai -->