### PR TITLE
actions/fix docker image promotion logic

### DIFF
--- a/.github/workflows/action-publish-docker.yml
+++ b/.github/workflows/action-publish-docker.yml
@@ -77,30 +77,38 @@ jobs:
             type=raw,value=${{ inputs.CONFIG_NAME }}-${{ inputs.COMMIT_SHA }}
             type=sha,format=long
 
-      # For promotions, retag existing prodtest image
+      # For promotions, retag the previous environment's image
+      # prodtest -> prodbeta -> prod
       - name: Promote tx-processor image (retag)
         if: inputs.IS_PROMOTION == true
         run: |
-          echo "Promoting prodtest image to ${{ inputs.CONFIG_NAME }}"
+          CONFIG="${{ inputs.CONFIG_NAME }}"
+          if [ "$CONFIG" = "prodbeta" ]; then
+            SOURCE_TAG="prodtest-latest"
+          elif [ "$CONFIG" = "prod" ]; then
+            SOURCE_TAG="prodbeta-latest"
+          else
+            echo "❌ Unexpected CONFIG_NAME for promotion: $CONFIG"
+            exit 1
+          fi
 
-          # Pull the prodtest image
-          SOURCE_TAG="prodtest-${{ inputs.COMMIT_SHA }}"
-          docker pull ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${SOURCE_TAG}
+          echo "Promoting ${SOURCE_TAG} to ${CONFIG}"
 
-          # Retag for new environment
-          docker tag \
-            ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${SOURCE_TAG} \
-            ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${{ inputs.CONFIG_NAME }}-latest
+          SOURCE="${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${SOURCE_TAG}"
+          docker pull "${SOURCE}"
 
-          docker tag \
-            ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${SOURCE_TAG} \
-            ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${{ inputs.CONFIG_NAME }}-${{ inputs.COMMIT_SHA }}
+          # Retag for target environment
+          docker tag "${SOURCE}" \
+            ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${CONFIG}-latest
+
+          docker tag "${SOURCE}" \
+            ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${CONFIG}-${{ inputs.COMMIT_SHA }}
 
           # Push new tags
-          docker push ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${{ inputs.CONFIG_NAME }}-latest
-          docker push ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${{ inputs.CONFIG_NAME }}-${{ inputs.COMMIT_SHA }}
+          docker push ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${CONFIG}-latest
+          docker push ${{ env.REGISTRY }}/${{ env.TX_PROCESSOR_IMAGE }}:${CONFIG}-${{ inputs.COMMIT_SHA }}
 
-          echo "✅ Image promoted successfully"
+          echo "✅ Image promoted from ${SOURCE_TAG} to ${CONFIG}"
 
       # - name: Extract metadata for VQA Service
       #   id: meta-vqa

--- a/.github/workflows/deploy-on-tag.yml
+++ b/.github/workflows/deploy-on-tag.yml
@@ -301,7 +301,7 @@ jobs:
     with:
       CONFIG_NAME: ${{ needs.determine-environment.outputs.environment }}
       COMMIT_SHA: ${{ needs.normalize-commit.outputs.commit }}
-      IS_PROMOTION: ${{ !contains(github.ref_name, '-test.') }}
+      IS_PROMOTION: ${{ needs.determine-environment.outputs.environment != 'prodtest' }}
 
   publish-services:
     needs: [wait-for-packages, determine-environment, normalize-commit]


### PR DESCRIPTION
Promotion logic uses *-latest instead of sha to allow additional commits on release prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved Docker image promotion workflow to dynamically map source images based on target deployment environments, replacing hard-coded references.
* Updated promotion detection logic to use environment parsing instead of tag name patterns, aligning promotion behavior with environment determination for more consistent deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->