### PR TITLE
Harvester/always log elements

### DIFF
--- a/apps/harvester/src/Harvester/agent/agentCallbacks.ts
+++ b/apps/harvester/src/Harvester/agent/agentCallbacks.ts
@@ -14,7 +14,6 @@ export class AgentCallbacks extends TaskSessionBase implements IAgentCallbacks {
   constructor(params: AgentParams) {
     super(params, {
       target: params.target,
-      // This only comes into affect if "verbose logging" is enabled
       writeScreenshotOnElement: true,
     })
   }

--- a/apps/harvester/src/Harvester/replay/replayCallbacks.ts
+++ b/apps/harvester/src/Harvester/replay/replayCallbacks.ts
@@ -15,7 +15,6 @@ export class HarvesterReplayCallbacks extends TaskSessionBase implements IReplay
   constructor(options: CallbackOptions) {
     super(options, {
       writeScreenshotOnElement: true,
-      skipSections: [],
     });
   }
 

--- a/libs/scraper-agent/src/agentSerializer.ts
+++ b/libs/scraper-agent/src/agentSerializer.ts
@@ -180,15 +180,25 @@ export class AgentSerializer implements Disposable {
   }
 
   async logMhtml(page: Page) {
+    // Skip MHTML capture for file:// URLs - the source is already an MHTML file
+    const url = page.url();
+    if (url.startsWith("file://")) {
+      log.info(`Skipping MHTML capture for file:// URL: ${url}`);
+      return;
+    }
+    const cdp = await page.createCDPSession();
     try {
       const outMhtml = this.toPath(this.tracker.currentSection, `${this.tracker.step}`, "mhtml");
-      const cdp = await page.createCDPSession();
       const { data } = await cdp.send('Page.captureSnapshot', { format: 'mhtml' });
       writeFileSync(outMhtml, data);
+      log.info(`Wrote MHTML for section ${this.tracker.currentSection}[${this.tracker.step}]`);
     }
     catch (e) {
       log.error(e, `Error taking MHTML for section ${this.tracker.currentSection}`);
       // This is a pain, but it happens - let's move on anyway
+    }
+    finally {
+      await cdp.detach();
     }
   }
 
@@ -230,8 +240,13 @@ export class AgentSerializer implements Disposable {
     writeFileSync(path.join(dumpFolder, `error.html`), content);
     // Lastly, try for MHTML
     const cdp = await page.createCDPSession();
-    const { data } = await cdp.send('Page.captureSnapshot', { format: 'mhtml' });
-    writeFileSync(path.join(dumpFolder, `error.mhtml`), data);
+    try {
+      const { data } = await cdp.send('Page.captureSnapshot', { format: 'mhtml' });
+      writeFileSync(path.join(dumpFolder, `error.mhtml`), data);
+    }
+    finally {
+      await cdp.detach();
+    }
 
     // write the error out too, if possible
     writeFileSync(path.join(dumpFolder, `error.json`), JSON.stringify(error));

--- a/libs/scraper-agent/src/agentSerializer.ts
+++ b/libs/scraper-agent/src/agentSerializer.ts
@@ -33,7 +33,6 @@ export type SerializerOptions = {
   recordFolder: string,
   // The bank names (constant throughout an execution)
   target: string,
-  skipSections?: SectionName[],
   // Used in replay - if true, we will take a screenshot
   // on every element found
   writeScreenshotOnElement?: boolean,
@@ -48,8 +47,6 @@ export class AgentSerializer implements Disposable {
   options: SerializerOptions;
   get recordFolder() { return this.options.recordFolder; }
   get target() { return this.options.target; }
-  // By default, we skip the initial section
-  get skipSections() { return this.options.skipSections ?? ["Initial"]; }
   get writeScreenshotOnElement() { return this.options.writeScreenshotOnElement; }
 
   constructor(options: SerializerOptions) {
@@ -80,14 +77,9 @@ export class AgentSerializer implements Disposable {
   // Log every API call
   onApiCall = async (event: ApiCallEvent) => {
     try {
-      // Never skip errors
-      if (!event.error) {
-        if (this.pauseWriting()) {
-          return;
-        }
-        if (this.skipWriting(event)) {
-          return;
-        }
+      // Skip duplicate intents, but still log errors
+      if (!event.error && this.skipWriting(event)) {
+        return;
       }
 
       // Does the request include an image?
@@ -153,10 +145,6 @@ export class AgentSerializer implements Disposable {
     this.tracker.setCurrentSection(section);
   }
 
-  pauseWriting() {
-    return this.skipSections.includes(this.tracker.currentSection);
-  }
-
   skipWriting(event: ApiCallEvent) {
     if (event.method == "pageIntent") {
       // If this is the same as the last intent, skip it.
@@ -179,9 +167,6 @@ export class AgentSerializer implements Disposable {
   }
 
   async logScreenshot(screenshot: Buffer|Uint8Array): Promise<void> {
-    if (this.pauseWriting()) {
-      return;
-    }
     this.maybeIncrementSection(screenshot);
 
     // Write out the buffer
@@ -208,9 +193,6 @@ export class AgentSerializer implements Disposable {
   }
 
   async logJson(name?: string, data: any = {}, increment: boolean = true): Promise<void> {
-    if (this.pauseWriting()) {
-      return;
-    }
     const filename = `${this.tracker.step}-${this.tracker.elements}-${name}`;
     // Ensure we don't overwrite previous JSON files
     if (increment) {

--- a/libs/scraper-agent/src/agentSerializer.ts
+++ b/libs/scraper-agent/src/agentSerializer.ts
@@ -179,6 +179,21 @@ export class AgentSerializer implements Disposable {
     // }
   }
 
+  private async captureMhtml(page: Page, outPath: string) {
+    const cdp = await page.createCDPSession();
+    try {
+      const { data } = await cdp.send('Page.captureSnapshot', { format: 'mhtml' });
+      writeFileSync(outPath, data);
+    }
+    catch (e) {
+      log.error(e, `Error capturing MHTML to ${outPath}`);
+      // This is a pain, but it happens - let's move on anyway
+    }
+    finally {
+      try { await cdp.detach(); } catch (e) { log.error(e, 'Error detaching CDP session'); }
+    }
+  }
+
   async logMhtml(page: Page) {
     // Skip MHTML capture for file:// URLs - the source is already an MHTML file
     const url = page.url();
@@ -186,20 +201,9 @@ export class AgentSerializer implements Disposable {
       log.info(`Skipping MHTML capture for file:// URL: ${url}`);
       return;
     }
-    const cdp = await page.createCDPSession();
-    try {
-      const outMhtml = this.toPath(this.tracker.currentSection, `${this.tracker.step}`, "mhtml");
-      const { data } = await cdp.send('Page.captureSnapshot', { format: 'mhtml' });
-      writeFileSync(outMhtml, data);
-      log.info(`Wrote MHTML for section ${this.tracker.currentSection}[${this.tracker.step}]`);
-    }
-    catch (e) {
-      log.error(e, `Error taking MHTML for section ${this.tracker.currentSection}`);
-      // This is a pain, but it happens - let's move on anyway
-    }
-    finally {
-      await cdp.detach();
-    }
+    const outMhtml = this.toPath(this.tracker.currentSection, `${this.tracker.step}`, "mhtml");
+    await this.captureMhtml(page, outMhtml);
+    log.info(`Wrote MHTML for section ${this.tracker.currentSection}[${this.tracker.step}]`);
   }
 
   async logJson(name?: string, data: any = {}, increment: boolean = true): Promise<void> {
@@ -239,14 +243,7 @@ export class AgentSerializer implements Disposable {
     const content = await page.content();
     writeFileSync(path.join(dumpFolder, `error.html`), content);
     // Lastly, try for MHTML
-    const cdp = await page.createCDPSession();
-    try {
-      const { data } = await cdp.send('Page.captureSnapshot', { format: 'mhtml' });
-      writeFileSync(path.join(dumpFolder, `error.mhtml`), data);
-    }
-    finally {
-      await cdp.detach();
-    }
+    await this.captureMhtml(page, path.join(dumpFolder, `error.mhtml`));
 
     // write the error out too, if possible
     writeFileSync(path.join(dumpFolder, `error.json`), JSON.stringify(error));

--- a/libs/scraper-agent/tools/recordSamples/recordSamples.ts
+++ b/libs/scraper-agent/tools/recordSamples/recordSamples.ts
@@ -16,7 +16,7 @@ mkdirSync(recordFolder, { recursive: true });
 
 const target = process.argv[2] ?? "Target";
 using askUser = new AskUserConsole();
-const writer = new AgentSerializer({ recordFolder, target, skipSections: [] });
+const writer = new AgentSerializer({ recordFolder, target });
 await using agent = await Agent.create(target, askUser);
 const page = agent.page;
 

--- a/libs/scraper-agent/tools/updateElement/updateTest.ts
+++ b/libs/scraper-agent/tools/updateElement/updateTest.ts
@@ -32,7 +32,6 @@ setApi(mockApi as any);
 const logger = new AgentSerializer({
   recordFolder,
   target,
-  skipSections: [],
 });
 
 // await selectDestination(handler, askUser, mockApi as any);

--- a/libs/scraper/src/elements.score.ts
+++ b/libs/scraper/src/elements.score.ts
@@ -272,16 +272,21 @@ function getEstimatedTextScore(potential: ElementData, original: SearchElementDa
       levenshtein(cleanOriginal + ".00", cleanPotential)
     );
 
-    // Our scoring is non-linear.  If the original length is less than 5, then
-    // even a few mis-matches can be a big penalty (eg, $0 => $0.00).  For this length, we simply lose
-    // 10% for each change made
-    if (cleanOriginal.length < 5) {
-      return Math.max(-0.5, 1 - (distance / 5));
+    // Very short strings (< 3 chars) are too ambiguous for fuzzy matching.
+    // Require exact match (after the .00 fallback distance calculation above).
+    // This prevents "x" matching "fr" while still allowing "$5" to match "$5.00".
+    if (cleanOriginal.length < 3) {
+      return distance === 0 ? 1 : -0.5;
     }
-    // For longer strings, we just
-    else {
+
+    // Short strings (3-4 chars): penalize edit distance relative to actual length.
+    // A few mismatches can be significant (e.g., "$0" vs "$0.00" has distance 3).
+    if (cleanOriginal.length < 5) {
       return Math.max(-0.5, 1 - (distance / cleanOriginal.length));
     }
+
+    // For longer strings, use edit distance relative to original length
+    return Math.max(-0.5, 1 - (distance / cleanOriginal.length));
   }
   return 0;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot/MHTML capture reliability with safer cleanup even when capture fails.
  * Ensured MHTML is no longer skipped for section-based progress, and enhanced error capture consistency.
  * Refined estimated text scoring heuristics for more accurate fuzzy matching.

* **Chores**
  * Removed section-skipping configuration from agent/serializer setup and related tooling scripts.
  * Reduced redundant non-error API event logging while still recording all errors.
  * Standardized callback initialization to always enable element screenshot output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->