### PR TITLE
Limit browser to a single tab, filter non-URL navigations

### DIFF
--- a/libs/scraper/src/puppeteer-init/newPage.ts
+++ b/libs/scraper/src/puppeteer-init/newPage.ts
@@ -1,4 +1,4 @@
-import puppeteerVanilla, { BrowserContext, type Browser } from 'puppeteer';
+import puppeteerVanilla, { BrowserContext, Page, type Browser } from 'puppeteer';
 import { addExtra } from 'puppeteer-extra';
 import { getPlugins } from './plugins';
 import { registerElementAttrFns } from '../elements';
@@ -100,11 +100,17 @@ async function getPage(contextName = "default") {
   });
 
   // On boot, close any existing pages.
-  const existingPages = await context.pages();
-  for (const p of existingPages.slice(1)) await p.close();
-  const page = existingPages[0] ?? await context.newPage();
+  const [first, ...rest] = await context.pages();
+  await closeAllPages(rest);
+  const page = first ?? await context.newPage();
   // Navigate stale tabs to blank before handing off
-  if (page.url() !== 'about:blank') await page.goto('about:blank');
+  if (page.url() !== 'about:blank') {
+    try {
+      await page.goto('about:blank');
+    } catch (e) {
+      log.warn({ error: e }, 'Failed to navigate to about:blank');
+    }
+  }
 
   return {
     browser,
@@ -156,4 +162,14 @@ export async function closeBrowser() {
   // Force-delete singleton locks.  If the browser fails to close
   // for some reason, this will ensure the next run can start cleanly.
   await cleanProfileLocks();
+}
+
+
+async function closeAllPages(extraPages: Page[]) {
+  const closeResults = await Promise.allSettled(extraPages.map(p => p.close()));
+  closeResults.forEach((r, i) => {
+    if (r.status === 'rejected') {
+      log.warn({ error: r.reason }, `Failed to close extra page index=${i + 1}`);
+    }
+  });
 }

--- a/libs/scraper/src/puppeteer-init/newPage.ts
+++ b/libs/scraper/src/puppeteer-init/newPage.ts
@@ -99,11 +99,16 @@ async function getPage(contextName = "default") {
     globalThis.__scraper__ = undefined
   });
 
-  // On boot, return the default (blank) page
-  const [page] = await context.pages();
+  // On boot, close any existing pages.
+  const existingPages = await context.pages();
+  for (const p of existingPages.slice(1)) await p.close();
+  const page = existingPages[0] ?? await context.newPage();
+  // Navigate stale tabs to blank before handing off
+  if (page.url() !== 'about:blank') await page.goto('about:blank');
+
   return {
     browser,
-    page: page ?? (await context.newPage())
+    page
   };
 }
 

--- a/libs/scraper/src/record/recorder.ts
+++ b/libs/scraper/src/record/recorder.ts
@@ -106,7 +106,7 @@ export class Recorder extends EventEmitter implements AsyncDisposable {
     // log.debug("event name: " + event.type);
     switch (event.type) {
     case 'navigation':
-      if (event.to == 'about:blank') {
+      if (!event.to.startsWith('http')) {
         return;
       }
       this.step = this.step + 1;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved browser page initialization by reusing a single ready page and closing any extra pages in the selected context for a cleaner session.
  * Enhanced navigation recording so only HTTP-based navigations advance tracking, reducing irrelevant step changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->