### PR TITLE
Etransfer/enable revert

### DIFF
--- a/libs/apis/mocks/pricing.ts
+++ b/libs/apis/mocks/pricing.ts
@@ -5,7 +5,7 @@ import { DateTime } from "luxon";
 
 class RatesApi implements Pick<IRatesApi, keyof IRatesApi> {
 
-  getMany(_timestamps: number[], _options?: any): Promise<AxiosResponse<FXRate[]>> {
+  getMany(): Promise<AxiosResponse<FXRate[]>> {
     throw new Error("Method not implemented.");
   }
   async getSingle(_currencyCode: number, timestamp?: number, _options?: any): Promise<AxiosResponse<FXRate>> {
@@ -23,5 +23,6 @@ class RatesApi implements Pick<IRatesApi, keyof IRatesApi> {
     } as any);
   }
 }
-
-export const GetRatesApi = () => new RatesApi();
+// Use a constant object to enable mocking/spying in tests
+const mockRates = new RatesApi()
+export const GetRatesApi = () => mockRates;

--- a/libs/broker-db/src/transaction/types.ts
+++ b/libs/broker-db/src/transaction/types.ts
@@ -16,6 +16,10 @@ export type StateData = {
   hash?: string; // Most recent tx hash
   meta?: string; // Any metadata about this transition: eg confirmation numbers etc
   error?: string; // Any error data.  Could be merged into meta?
+  // The effective financial date of the action is happening on (eg settlement date, return date).
+  // Initially set to the action creation date, updated when transitions happen at
+  // a specific time (eg, conversion, transfer completion)
+  date: DateTime;
 }
 
 // The changes applied to an action
@@ -23,14 +27,12 @@ export type TransitionDelta = {
   // The date the transition was created.  May differ from
   // the applicable date of the action (eg, based on settlement dates etc)
   created: DateTime;
-  // The date the action happened.  This will be different than
-  // the created date.  For example, the recieved date for an
-  // e-transfer will be different than when the action is created.
-  // This date is primarily for reference, and not used internally
+  // The effective financial date of this transition.
+  // Optional on deltas — if omitted, the accumulated StateData.date is inherited.
   date?: DateTime;
   // The type of transition (ie, describes the effects of the transition: toCoin etc)
   type: string;
-} & StateData;
+} & Omit<StateData, 'date'>;
 
 // An action stores very little data directly.
 // Instead, it has an 'events' subcollection

--- a/libs/contract-core/mocks/contractcore_mocked.ts
+++ b/libs/contract-core/mocks/contractcore_mocked.ts
@@ -59,8 +59,8 @@ class TheCoinImp implements MockedCoin {
     "nonpayable"
   )
   uberTransfer = makeFn(
-    //  This function multiplies the value by 500,000 to simulate the conversion from CAD to TheCoin at xchange rate of 1 coin/$2 CAD
-    async (_chainId: BigNumberish, from: AddressLike, to: AddressLike, value: BigNumberish, ..._args: any[]) => await setLastTx(from, to, BigInt(value) * 500_000n),
+    //  This function multiplies the value by 5_000 to simulate the conversion from CAD to TheCoin at xchange rate of 1 coin/$2 CAD
+    async (_chainId: BigNumberish, from: AddressLike, to: AddressLike, value: BigNumberish, ..._args: any[]) => await setLastTx(from, to, BigInt(value) * 5000n),
     "nonpayable"
   )
   // Run during testing.  Remove once deployement is secure.

--- a/libs/contract-core/mocks/contractcore_mocked.ts
+++ b/libs/contract-core/mocks/contractcore_mocked.ts
@@ -59,7 +59,8 @@ class TheCoinImp implements MockedCoin {
     "nonpayable"
   )
   uberTransfer = makeFn(
-    async (_chainId: BigNumberish, from: AddressLike, to: AddressLike, value: BigNumberish, ..._args: any[]) => await setLastTx(from, to, value),
+    //  This function multiplies the value by 500,000 to simulate the conversion from CAD to TheCoin at xchange rate of 1 coin/$2 CAD
+    async (_chainId: BigNumberish, from: AddressLike, to: AddressLike, value: BigNumberish, ..._args: any[]) => await setLastTx(from, to, BigInt(value) * 500_000n),
     "nonpayable"
   )
   // Run during testing.  Remove once deployement is secure.

--- a/libs/rbcapi/src/index_mocked.ts
+++ b/libs/rbcapi/src/index_mocked.ts
@@ -1,5 +1,4 @@
 import { ETransferErrorCode, IBank } from "@thecointech/bank-interface";
-
 export { ETransferErrorCode };
 export { RbcStore } from './store'
 export function initBrowser() {};
@@ -8,18 +7,18 @@ export function closeBrowser() {}
 let result = 1234;
 export class RbcApi implements IBank {
   getBalance = () => Promise.resolve(10000);
-  depositETransfer = () => {
+  depositETransfer = (): ReturnType<IBank["depositETransfer"]> => {
     result += 1;
     return Promise.resolve({
-      message:  ETransferErrorCode.Success.toString(),
-      code:  ETransferErrorCode.Success,
+      message: ETransferErrorCode.Success.toString(),
+      code: ETransferErrorCode.Success,
       confirmation: result += 1,
     });
-  };
-  sendETransfer = () => Promise.resolve(result += 1);
-  payBill = () => Promise.resolve((result += 1).toString());
-  fetchLatestTransactions = () => Promise.resolve([]);
-  getTransactions = () => Promise.resolve([]);
+  }
+  sendETransfer = (): ReturnType<IBank["sendETransfer"]> => Promise.resolve(result += 1);
+  payBill = (): ReturnType<IBank["payBill"]> => Promise.resolve((result += 1).toString());
+  fetchLatestTransactions = (): ReturnType<IBank["fetchLatestTransactions"]> => Promise.resolve([]);
+  getTransactions = (): ReturnType<IBank["getTransactions"]> => Promise.resolve([]);
 
   static async create() {
     return new RbcApi();

--- a/libs/tx-bill/src/graph.test.ts
+++ b/libs/tx-bill/src/graph.test.ts
@@ -1,0 +1,89 @@
+import { jest } from '@jest/globals';
+import { init as FirestoreInit, getFirestore } from '@thecointech/firestore';
+import { ContractCore } from '@thecointech/contract-core';
+import { DateTime } from 'luxon';
+import Decimal from 'decimal.js-light';
+import { BillAction } from '@thecointech/broker-db';
+import { getSigner } from '@thecointech/signers';
+import { GetRatesApi } from '@thecointech/apis/pricing';
+import { RbcApi } from '@thecointech/rbcapi';
+import type { BillPayeePacket } from '@thecointech/types';
+import { graph } from './graph';
+import { StateMachineProcessor, getCurrentState } from '@thecointech/tx-statemachine';
+
+jest.useFakeTimers();
+
+const ratesApi = GetRatesApi();
+const getSingleSpy = jest.spyOn(ratesApi, 'getSingle');
+
+const bank = await RbcApi.create();
+const payBillSpy = jest.spyOn(bank, 'payBill');
+
+// Action created Saturday noon
+const createDate = DateTime.now()
+  .minus({ days: DateTime.now().weekday + 1 })
+  .set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+
+// Process on Monday afternoon
+const processingTime = createDate.plus({ days: 2 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 });
+
+const billAmount = new Decimal(100000000);
+const userAddress = '0x0000000000000000000000000000000000000001';
+
+// Pre-decrypted instructions passed directly to avoid crypto in tests
+const instructions: BillPayeePacket = {
+  payee: 'Hydro',
+  accountNumber: '123456789',
+};
+
+beforeEach(async () => {
+  await FirestoreInit();
+  jest.clearAllMocks();
+});
+
+it('bill payment: happy path reaches complete', async () => {
+  jest.setSystemTime(processingTime.toJSDate());
+
+  const action: BillAction = {
+    address: userAddress,
+    type: 'Bill',
+    data: {
+      initial: {
+        transfer: {
+          chainId: 1,
+          from: userAddress,
+          to: process.env.WALLET_BrokerCAD_ADDRESS!,
+          value: billAmount.toNumber(),
+          fee: 0,
+          timestamp: createDate.toMillis(),
+          signature: '',
+        },
+        instructionPacket: { encryptedPacket: '', version: '' },
+        signature: '',
+      },
+      initialId: 'test-bill-1',
+      date: createDate,
+    },
+    history: [],
+    doc: getFirestore().doc('/Bill/test-bill-1') as unknown as BillAction['doc'],
+  };
+
+  const contract = await ContractCore.connect(await getSigner("BrokerCAD"));
+  const processor = new StateMachineProcessor(graph, contract, bank);
+
+  const container = await processor.execute(instructions, action);
+  const finalState = getCurrentState(container);
+  expect(finalState.name).toBe('complete');
+
+  // toFiat called getSingle once for the coin -> fiat conversion
+  expect(getSingleSpy).toHaveBeenCalledTimes(1);
+
+  // payBill was called once
+  expect(payBillSpy).toHaveBeenCalledTimes(1);
+
+  // Final state: fiat and coin are zeroed out
+  expect(finalState.data.coin?.isZero()).toBeTruthy();
+  expect(finalState.data.fiat?.isZero()).toBeTruthy();
+});
+
+// Reverting bill payments hasn't been implemented yet.

--- a/libs/tx-bill/src/transitions/payBill.ts
+++ b/libs/tx-bill/src/transitions/payBill.ts
@@ -57,7 +57,6 @@ const doPayBill: TransitionCallback<"Bill"> = async (container) => {
     ? {
         meta: confirmation.toString(),
         fiat: new Decimal(0),
-        date: DateTime.now(),
       }
     : { error: `Error Code: ${confirmation}`}
 }

--- a/libs/tx-bill/src/transitions/payBill.ts
+++ b/libs/tx-bill/src/transitions/payBill.ts
@@ -6,7 +6,6 @@ import { sign } from "@thecointech/utilities/SignedMessages";
 import { log } from "@thecointech/logging";
 import Decimal from 'decimal.js-light';
 import { getSigner } from '@thecointech/signers';
-import { DateTime } from 'luxon';
 import { makeTransition } from '@thecointech/tx-statemachine';
 
 //

--- a/libs/tx-bill/src/uberGraph.test.ts
+++ b/libs/tx-bill/src/uberGraph.test.ts
@@ -1,9 +1,10 @@
 import { jest } from "@jest/globals";
-import { init as FirestoreInit, getFirestore } from '@thecointech/firestore';
+import { init as FirestoreInit } from '@thecointech/firestore';
 import { ContractCore } from '@thecointech/contract-core';
 import { DateTime } from 'luxon';
 import Decimal from 'decimal.js-light';
-import { BillAction } from '@thecointech/broker-db';
+import { createAction } from '@thecointech/broker-db';
+import { BuildUberAction } from '@thecointech/utilities/UberAction';
 import { getSigner } from '@thecointech/signers';
 import { GetRatesApi } from '@thecointech/apis/pricing';
 import { RbcApi } from '@thecointech/rbcapi';
@@ -11,6 +12,8 @@ import type { BillPayeePacket } from '@thecointech/types';
 import { uberGraph } from './uberGraph';
 import { StateMachineProcessor, getCurrentState } from '@thecointech/tx-statemachine';
 import { ContractConverter } from '@thecointech/contract-plugin-converter';
+import { Wallet } from "ethers";
+import { NormalizeAddress } from '@thecointech/utilities';
 
 jest.useFakeTimers();
 
@@ -30,7 +33,7 @@ const processingTime = createDate.plus({ days: 2 }).set({ hour: 14, minute: 0, s
 // UberTransfer settles Friday afternoon
 const transferTime = createDate.plus({ days: 6 })
 
-const userAddress = '0x0000000000000000000000000000000000000001';
+const user = Wallet.createRandom();
 
 const instructions: BillPayeePacket = {
   payee: 'Hydro',
@@ -45,30 +48,20 @@ beforeEach(async () => {
 it('uberGraph bill payment: happy path reaches complete', async () => {
   jest.setSystemTime(processingTime.toJSDate());
 
-  const action: BillAction = {
-    address: userAddress,
-    type: 'Bill',
-    data: {
-      initial: {
-        transfer: {
-          chainId: 1,
-          from: userAddress,
-          to: process.env.WALLET_BrokerCAD_ADDRESS!,
-          amount: 100, // $100
-          currency: 124,
-          signedMillis: createDate.toMillis(),
-          transferMillis: transferTime.toMillis(),
-          signature: '',
-        },
-        instructionPacket: { encryptedPacket: '', version: '' },
-        signature: '',
-      },
-      initialId: 'test-uber-bill-1',
-      date: createDate,
-    },
-    history: [],
-    doc: getFirestore().doc('/Bill/test-uber-bill-1') as unknown as BillAction['doc'],
-  };
+  const address = NormalizeAddress(await user.getAddress());
+  const uberAction = await BuildUberAction(
+    {} as any,
+    user,
+    process.env.WALLET_BrokerCAD_ADDRESS!,
+    new Decimal(100),
+    124,
+    transferTime
+  );
+  const action = await createAction(address, "Bill", {
+    initial: uberAction,
+    date: DateTime.now(),
+    initialId: uberAction.signature
+  })
 
   const signer = await getSigner("BrokerCAD");
   const uc = await ContractConverter.connect(signer);

--- a/libs/tx-bill/src/uberGraph.test.ts
+++ b/libs/tx-bill/src/uberGraph.test.ts
@@ -1,105 +1,123 @@
 import { jest } from "@jest/globals";
-import { init } from '@thecointech/firestore';
-import { rawGraph } from './uberGraph';
+import { init as FirestoreInit, getFirestore } from '@thecointech/firestore';
+import { ContractCore } from '@thecointech/contract-core';
 import { DateTime } from 'luxon';
-import { getMockContainer } from "../internal/mockContainer";
+import Decimal from 'decimal.js-light';
+import { BillAction } from '@thecointech/broker-db';
+import { getSigner } from '@thecointech/signers';
+import { GetRatesApi } from '@thecointech/apis/pricing';
+import { RbcApi } from '@thecointech/rbcapi';
+import type { BillPayeePacket } from '@thecointech/types';
+import { uberGraph } from './uberGraph';
+import { StateMachineProcessor, getCurrentState } from '@thecointech/tx-statemachine';
+import { ContractConverter } from '@thecointech/contract-plugin-converter';
 
-jest.setTimeout(10 * 60 * 60 * 1000);
 jest.useFakeTimers();
 
-it('processes pending', async () => {
-  init()
-  const date = DateTime.now();
-  const container = await getMockContainer(date);
-  container.instructions = {} as any; // bypass encryption
-  let state = container.history[0];
+const ratesApi = GetRatesApi();
+const getSingleSpy = jest.spyOn(ratesApi, 'getSingle');
 
-  const incrementState = async () => {
-    const { action, next } = rawGraph[state!.name]
-    const r = await action(container);
-    if (!r) return;
+const bank = await RbcApi.create();
+const payBillSpy = jest.spyOn(bank, 'payBill');
 
-    if (r?.error) throw r.error;
-    const delta = {
-      created: DateTime.now(),
-      type: action.transitionName,
-      ...r,
-    }
-    const newState = {
-      delta,
-      data: {
-        ...state.data,
-        ...delta,
+// Action created Saturday noon
+const createDate = DateTime.now()
+  .minus({ weeks: 2, days: DateTime.now().weekday + 1 })
+  .set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+
+// First processed on the Monday (register, no settle)
+const processingTime = createDate.plus({ days: 2 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 });
+// UberTransfer settles Friday afternoon
+const transferTime = createDate.plus({ days: 6 })
+
+const userAddress = '0x0000000000000000000000000000000000000001';
+
+const instructions: BillPayeePacket = {
+  payee: 'Hydro',
+  accountNumber: '123456789',
+};
+
+beforeEach(async () => {
+  await FirestoreInit();
+  jest.clearAllMocks();
+});
+
+it('uberGraph bill payment: happy path reaches complete', async () => {
+  jest.setSystemTime(processingTime.toJSDate());
+
+  const action: BillAction = {
+    address: userAddress,
+    type: 'Bill',
+    data: {
+      initial: {
+        transfer: {
+          chainId: 1,
+          from: userAddress,
+          to: process.env.WALLET_BrokerCAD_ADDRESS!,
+          amount: 100, // $100
+          currency: 124,
+          signedMillis: createDate.toMillis(),
+          transferMillis: transferTime.toMillis(),
+          signature: '',
+        },
+        instructionPacket: { encryptedPacket: '', version: '' },
+        signature: '',
       },
-      name: next
-    }
-    container.history.push(newState);
-    state = newState;
-  }
+      initialId: 'test-uber-bill-1',
+      date: createDate,
+    },
+    history: [],
+    doc: getFirestore().doc('/Bill/test-uber-bill-1') as unknown as BillAction['doc'],
+  };
 
-  // First transfer doesn't actually do any transfers, so no logs
-  const provider = container.contract.runner.provider
-  const oldWait = provider.waitForTransaction
-  //@ts-ignore
-  provider.waitForTransaction = jest.fn(() => Promise.resolve({
-    confirmations: () => 3,
-    status: 1,
-    logs: [],
-  }));
+  const signer = await getSigner("BrokerCAD");
+  const uc = await ContractConverter.connect(signer);
+  const tcCore = await ContractCore.connect(signer);
+  const uberTransferSpy = jest.spyOn(tcCore, 'uberTransfer');
+  const processPendingSpy = jest.spyOn(uc, 'processPending');
+  const parseLogSpy = jest.spyOn(tcCore.interface, 'parseLog');
+  const processor = new StateMachineProcessor(uberGraph, tcCore, bank);
 
-  // Register pending transaction
-  expect(state.name).toBe("initial");
-  await incrementState();
-  expect(state.name).toBe("tcRegisterReady");
-  await incrementState();
-  expect(state.name).toBe("tcRegisterWaiting");
-  await incrementState();
-  expect(state.name).toBe("tcWaitToFinalize");
-  expect(state?.delta.coin).toBeFalsy();
-  expect(state?.delta.fiat).toBeFalsy();
+  // On our first run, waitForTransaction does not return
+  // any logs (the default mock will return `ExactTransfer`)
+  parseLogSpy.mockImplementationOnce(() => null);
+  const initContainer = await processor.execute(instructions, action);
+  const initState = getCurrentState(initContainer);
+  // The transfer has been accepted and registered, but remains in 'waiting' state
+  // until the transferMillis has passed.
+  expect(initState.name).toBe('tcWaitToFinalize');
+  expect(getSingleSpy).toHaveBeenCalledTimes(0);
+  expect(uberTransferSpy).toHaveBeenCalledTimes(1);
+  expect(processPendingSpy).toHaveBeenCalledTimes(0);
+  expect(payBillSpy).toHaveBeenCalledTimes(0);
 
-  // Wait for the timestamp to pass
-  await incrementState();
-  expect(state.name).toBe("tcWaitToFinalize");
-  // Still waiting - run again, same result
-  await incrementState();
-  expect(state.name).toBe("tcWaitToFinalize");
+  // Process again wed, no change
+  jest.setSystemTime(processingTime.plus({ days: 2 }).toJSDate());
+  action.history = initContainer.history.map(h => h.delta).slice(1);
+  const waitContainer = await processor.execute(instructions, action);
+  const waitState = getCurrentState(waitContainer);
+  expect(waitState.name).toBe('tcWaitToFinalize');
+  expect(getSingleSpy).toHaveBeenCalledTimes(0);
+  expect(uberTransferSpy).toHaveBeenCalledTimes(1);
+  expect(waitContainer.history.length).toEqual(initContainer.history.length);
 
-  // Wait a day, run again.  This time we clear the pending transfer
-  provider.waitForTransaction = oldWait;
-  jest.setSystemTime(date.plus({ days: 1 }).toJSDate());
-  await incrementState();
-  expect(state.name).toBe("tcFinalizeInitial");
+  // Process again fri, this time it settles
+  jest.setSystemTime(processingTime.plus({ days: 5 }).toJSDate());
+  const finalContainer = await processor.execute(instructions, action);
+  const finalState = getCurrentState(finalContainer);
+  expect(finalState.name).toBe('complete');
 
-  await incrementState();
-  expect(state.name).toBe("tcFinalizeReady");
-  await incrementState();
-  expect(state.name).toBe("tcFinalizeWaiting");
-  jest.useRealTimers();
-  // jest.setSystemTime(date.plus({ days: 2 }).toJSDate());
-  await incrementState();
-  expect(state.name).toBe("coinTransferComplete");
-  expect(state?.delta.coin).toBeDefined();
-  expect(state?.delta.fiat).toBeUndefined();
+  // toFiat called getSingle once for the coin -> fiat conversion
+  expect(processPendingSpy).toHaveBeenCalledTimes(1);
+  expect(getSingleSpy).toHaveBeenCalledTimes(1);
+  expect(payBillSpy).toHaveBeenCalledTimes(1);
+  
+  const [[, calledTimestamp]] = getSingleSpy.mock.calls as [[number, number]];
+  const settledDate = DateTime.fromMillis(calledTimestamp);
+  expect(settledDate).toEqual(transferTime);
 
-  // Run currency conversion
-  // Just in case you're working late into the night... let's wait for the next day
-  jest.useFakeTimers();
-  jest.setSystemTime(date.plus({ days: 2 }).set({hour: 12}).toJSDate());
-  await incrementState();
-  expect(state.name).toBe("billInitial");
-  expect(state?.delta.coin?.toNumber()).toBe(0);
-  expect(state?.delta.fiat?.toNumber()).toBeGreaterThan(0);
-
-  // We have fiat, complete bill payment
-  await incrementState();
-  expect(state.name).toBe("billReady");
-  await incrementState();
-  expect(state.name).toBe("billResult");
-  expect(state?.delta.fiat?.toNumber()).toBe(0);
-
-  // All done
-  await incrementState();
-  expect(state.name).toBe("complete");
+  // Final state: fiat and coin are zeroed out
+  expect(finalState.data.coin?.isZero()).toBeTruthy();
+  expect(finalState.data.fiat?.isZero()).toBeTruthy();
 })
 

--- a/libs/tx-deposit/package.json
+++ b/libs/tx-deposit/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "prepublishOnly": "yarn run -T rimraf ./build/.buildinfo",
     "build": "run -T tsc -b",
-    "clean": "rimraf ./build && rimraf ./coverage"
+    "clean": "rimraf ./build && rimraf ./coverage",
+    "test": "run :jest"
   },
   "files": [
     "build/**/*"

--- a/libs/tx-deposit/src/graph.etransfer.test.ts
+++ b/libs/tx-deposit/src/graph.etransfer.test.ts
@@ -9,6 +9,8 @@ import { ETransferErrorCode } from '@thecointech/bank-interface';
 import type { eTransferData } from '@thecointech/tx-gmail';
 import { RbcApi } from '@thecointech/rbcapi';
 import { GetRatesApi } from '@thecointech/apis/pricing';
+import { etransfer } from './graph.etransfer';
+import { StateMachineProcessor, getCurrentState } from '@thecointech/tx-statemachine';
 
 jest.useFakeTimers();
 
@@ -51,9 +53,6 @@ beforeEach(async () => {
 });
 
 it('etransfer deposit uses the deposit time for conversion, not the action creation date', async () => {
-  const { etransfer } = await import('./graph.etransfer');
-  const { StateMachineProcessor, getCurrentState } = await import('@thecointech/tx-statemachine');
-
   const action: BuyAction = {
     address: userAddress,
     type: 'Buy',
@@ -108,9 +107,6 @@ it('etransfer deposit uses the deposit time for conversion, not the action creat
 });
 
 it('etransfer deposit fails gracefully when bank is unavailable', async () => {
-  const { etransfer } = await import('./graph.etransfer');
-  const { StateMachineProcessor, getCurrentState } = await import('@thecointech/tx-statemachine');
-
   depositSpy.mockResolvedValue({
     code: ETransferErrorCode.UnknownError,
     message: 'Bank API unavailable',

--- a/libs/tx-deposit/src/graph.etransfer.test.ts
+++ b/libs/tx-deposit/src/graph.etransfer.test.ts
@@ -1,0 +1,141 @@
+import { jest } from '@jest/globals';
+import { init as FirestoreInit, getFirestore } from '@thecointech/firestore';
+import { ContractCore } from '@thecointech/contract-core';
+import { DateTime } from 'luxon';
+import Decimal from 'decimal.js-light';
+import { BuyAction } from '@thecointech/broker-db';
+import { getSigner } from '@thecointech/signers';
+import { ETransferErrorCode } from '@thecointech/bank-interface';
+import type { eTransferData } from '@thecointech/tx-gmail';
+import { RbcApi } from '@thecointech/rbcapi';
+import { GetRatesApi } from '@thecointech/apis/pricing';
+
+jest.useFakeTimers();
+
+const ratesApi = GetRatesApi()
+const getSingleSpy = jest.spyOn(ratesApi, 'getSingle')
+
+const bank = await RbcApi.create();
+const depositSpy = jest.spyOn(bank, 'depositETransfer');
+
+// e-Transfer was received on Saturday noon
+const recieved = DateTime.now()
+  .minus({ days: DateTime.now().weekday + 1 })
+  .set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+
+// Action was created at the same time the e-transfer arrived
+const createDate = recieved;
+
+// We process it on Monday (next open market day)
+const processingTime = recieved.plus({ days: 2 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 });
+
+const depositAmount = new Decimal(100);
+const userAddress = '0x0000000000000000000000000000000000000001';
+
+const instructions: eTransferData = {
+  name: 'Test User',
+  email: 'test@example.com',
+  id: 'etransfer-abc-123',
+  cad: depositAmount,
+  address: userAddress,
+  recieved,
+  depositUrl: 'https://example.com/deposit',
+  // no `raw` — labelEmail will gracefully log and return { meta: 'Tag not set' }
+};
+
+beforeEach(async () => {
+  await FirestoreInit();
+  // Processing happens on Monday
+  jest.setSystemTime(processingTime.toJSDate());
+  jest.clearAllMocks();
+});
+
+it('etransfer deposit uses the deposit time for conversion, not the action creation date', async () => {
+  const { etransfer } = await import('./graph.etransfer');
+  const { StateMachineProcessor, getCurrentState } = await import('@thecointech/tx-statemachine');
+
+  const action: BuyAction = {
+    address: userAddress,
+    type: 'Buy',
+    data: {
+      initial: { amount: depositAmount, type: 'etransfer' },
+      initialId: 'test-etransfer-1',
+      date: createDate,
+    },
+    history: [],
+    doc: getFirestore().doc('/Buy/test-etransfer-1') as unknown as BuyAction['doc'],
+  };
+
+  const contract = await ContractCore.connect(await getSigner("BrokerCAD"));
+  const processor = new StateMachineProcessor(etransfer, contract, bank);
+
+  const container = await processor.execute(instructions, action);
+  const finalState = getCurrentState(container);
+  expect(finalState.name).toBe('complete');
+
+  // depositFiat sets date: DateTime.now() — which is Monday (processingTime)
+  // toCoin calls nextOpenTimestamp(Monday) => Monday market open at 9:32
+  expect(getSingleSpy).toHaveBeenCalledTimes(1);
+  const [[, calledTimestamp]] = getSingleSpy.mock.calls as [[number, number]];
+  const settledDate = DateTime.fromMillis(calledTimestamp);
+  expect(settledDate.weekday).toBe(1); // Monday
+  expect(settledDate.hour).toBe(9);
+  expect(settledDate.minute).toBe(32);
+
+  // Verify date propagation through states:
+  // [0] initial    => createDate (seeded from action.data.date)
+  // [1] labelled   => no date delta, inherits createDate
+  // [2] depositReady => preTransfer, no date delta
+  // [3] depositResult => depositFiat sets date: DateTime.now() (Monday)
+  // ...onwards inherits Monday
+  const dates = container.history.map(h => h.data.date);
+  expect(dates[0].toMillis()).toBe(createDate.toMillis());
+  // toCoin's settled date should match what getSingle was called with
+  const toCoinIdx = container.history.findIndex(h => h.delta.type === 'toCoin');
+  expect(dates[toCoinIdx].toMillis()).toBe(settledDate.toMillis());
+  // Final state inherits the settled date
+  expect(finalState.data.date.toMillis()).toBe(settledDate.toMillis());
+
+  // bank.depositETransfer was called once
+  expect(depositSpy).toHaveBeenCalledTimes(1);
+
+  // Coin was produced by toCoin
+  expect(container.history[toCoinIdx].delta.coin?.gt(0)).toBeTruthy();
+
+  // After sendCoin the coin balance resets to zero
+  expect(finalState.data.coin?.isZero()).toBeTruthy();
+  expect(finalState.data.fiat?.isZero()).toBeTruthy();
+});
+
+it('etransfer deposit fails gracefully when bank is unavailable', async () => {
+  const { etransfer } = await import('./graph.etransfer');
+  const { StateMachineProcessor, getCurrentState } = await import('@thecointech/tx-statemachine');
+
+  depositSpy.mockResolvedValue({
+    code: ETransferErrorCode.UnknownError,
+    message: 'Bank API unavailable',
+  });
+
+  const action: BuyAction = {
+    address: userAddress,
+    type: 'Buy',
+    data: {
+      initial: { amount: depositAmount, type: 'etransfer' },
+      initialId: 'test-etransfer-fail',
+      date: createDate,
+    },
+    history: [],
+    doc: getFirestore().doc('/Buy/test-etransfer-fail') as unknown as BuyAction['doc'],
+  };
+
+  const contract = await ContractCore.connect(await getSigner("BrokerCAD"));
+  const processor = new StateMachineProcessor(etransfer, contract, bank as any);
+
+  const container = await processor.execute(instructions, action);
+  const finalState = getCurrentState(container);
+
+  // Should land in error state (depositResult.onError -> requestManual -> error)
+  expect(finalState.name).toBe('error');
+  // No conversion should have happened
+  expect(getSingleSpy).not.toHaveBeenCalled();
+});

--- a/libs/tx-deposit/src/graph.manual.test.ts
+++ b/libs/tx-deposit/src/graph.manual.test.ts
@@ -1,0 +1,95 @@
+import { jest } from '@jest/globals';
+import { init as FirestoreInit, getFirestore } from '@thecointech/firestore';
+import { ContractCore } from '@thecointech/contract-core';
+import { DateTime } from 'luxon';
+import Decimal from 'decimal.js-light';
+import { BuyAction } from '@thecointech/broker-db';
+import * as brokerDbTxs from '@thecointech/broker-db/transaction';
+import { getSigner } from '@thecointech/signers';
+
+jest.useFakeTimers();
+
+const getSingle = jest.fn<(currency: number, timestamp: number) => Promise<any>>();
+jest.unstable_mockModule('@thecointech/apis/pricing', () => ({
+  GetRatesApi: () => ({
+    getSingle,
+  })
+}))
+
+jest.unstable_mockModule('@thecointech/broker-db/transaction', () =>
+  Object.keys(brokerDbTxs).reduce((acc, key) => ({ ...acc, [key]: jest.fn() }), {})
+);
+
+// The action was created on Saturday noon (before market open)
+const createDate = DateTime.now()
+  .minus({ days: DateTime.now().weekday + 1 })
+  .set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+
+// The deposit happened on sunday
+const depositDate = createDate.plus({ days: 1 });
+
+const depositAmount = new Decimal(100);
+const fxRate = 2.0; // 1 coin = $2 fiat
+
+beforeEach(async () => {
+  await FirestoreInit();
+  // It's currently monday at noon when we are processing this
+  jest.setSystemTime(depositDate.plus({ day: 1 }).toJSDate());
+  jest.resetAllMocks();
+  getSingle.mockResolvedValue({
+    status: 200,
+    data: { fxRate: 1, sell: fxRate, buy: fxRate },
+  });
+});
+
+it('manual deposit uses the deposit date for conversion, not the action creation date', async () => {
+  const { manual } = await import('./graph.manual');
+  const { StateMachineProcessor, getCurrentState } = await import('@thecointech/tx-statemachine');
+
+  const deposit = {
+    fiat: depositAmount,
+    meta: 'test-deposit',
+    date: depositDate,
+  };
+
+  const action: BuyAction = {
+    address: '0x0000000000000000000000000000000000000001',
+    type: 'Buy',
+    data: {
+      initial: { amount: depositAmount, type: 'other' },
+      initialId: 'test-manual-1',
+      date: createDate,  // action created Sunday; deposit happened Wednesday
+    },
+    history: [],
+    doc: getFirestore().doc('/Buy/test-manual-1') as unknown as BuyAction['doc'],
+  };
+
+  const contract = await ContractCore.connect(await getSigner("BrokerCAD"));
+  const processor = new StateMachineProcessor(manual(deposit), contract, null);
+
+  const container = await processor.execute(null, action);
+  const finalState = getCurrentState(container);
+  expect(finalState.name).toBe('complete');
+
+  // toCoin must have fetched the rate using the deposit date, not the action creation date.
+  expect(getSingle).toHaveBeenCalledTimes(1);
+  const [[, calledTimestamp]] = getSingle.mock.calls as [[number, number]];
+
+  // nextOpenTimestamp(depositDate=Sunday) == monday morning. 
+  const settledDate = DateTime.fromMillis(calledTimestamp);
+  expect(settledDate.weekday).toBe(1); // Monday
+  expect(settledDate.hour).toBe(9);
+  expect(settledDate.minute).toBe(32);
+
+  const dates = container.history.map(h => h.data.date);
+  expect(dates[0]).toEqual(createDate)
+  expect(dates[1]).toEqual(depositDate)
+  expect(dates[2].toString()).toEqual(settledDate.toString())
+  expect(finalState.data.date.toMillis()).toBe(settledDate.toMillis());
+
+  // We convert to coin
+  expect(container.history[2].delta.coin?.gt(0)).toBeTruthy();
+  // But end flat
+  expect(finalState.data.coin?.isZero()).toBeTruthy();
+  expect(finalState.data.fiat?.isZero()).toBeTruthy();
+});

--- a/libs/tx-deposit/src/graph.manual.test.ts
+++ b/libs/tx-deposit/src/graph.manual.test.ts
@@ -4,21 +4,13 @@ import { ContractCore } from '@thecointech/contract-core';
 import { DateTime } from 'luxon';
 import Decimal from 'decimal.js-light';
 import { BuyAction } from '@thecointech/broker-db';
-import * as brokerDbTxs from '@thecointech/broker-db/transaction';
 import { getSigner } from '@thecointech/signers';
+import { GetRatesApi } from '@thecointech/apis/pricing';
 
 jest.useFakeTimers();
 
-const getSingle = jest.fn<(currency: number, timestamp: number) => Promise<any>>();
-jest.unstable_mockModule('@thecointech/apis/pricing', () => ({
-  GetRatesApi: () => ({
-    getSingle,
-  })
-}))
-
-jest.unstable_mockModule('@thecointech/broker-db/transaction', () =>
-  Object.keys(brokerDbTxs).reduce((acc, key) => ({ ...acc, [key]: jest.fn() }), {})
-);
+const ratesApi = GetRatesApi()
+const getSingleSpy = jest.spyOn(ratesApi, 'getSingle')
 
 // The action was created on Saturday noon (before market open)
 const createDate = DateTime.now()
@@ -27,19 +19,13 @@ const createDate = DateTime.now()
 
 // The deposit happened on sunday
 const depositDate = createDate.plus({ days: 1 });
-
 const depositAmount = new Decimal(100);
-const fxRate = 2.0; // 1 coin = $2 fiat
 
 beforeEach(async () => {
   await FirestoreInit();
   // It's currently monday at noon when we are processing this
   jest.setSystemTime(depositDate.plus({ day: 1 }).toJSDate());
-  jest.resetAllMocks();
-  getSingle.mockResolvedValue({
-    status: 200,
-    data: { fxRate: 1, sell: fxRate, buy: fxRate },
-  });
+  jest.clearAllMocks();
 });
 
 it('manual deposit uses the deposit date for conversion, not the action creation date', async () => {
@@ -72,8 +58,8 @@ it('manual deposit uses the deposit date for conversion, not the action creation
   expect(finalState.name).toBe('complete');
 
   // toCoin must have fetched the rate using the deposit date, not the action creation date.
-  expect(getSingle).toHaveBeenCalledTimes(1);
-  const [[, calledTimestamp]] = getSingle.mock.calls as [[number, number]];
+  expect(getSingleSpy).toHaveBeenCalledTimes(1);
+  const [[, calledTimestamp]] = getSingleSpy.mock.calls as [[number, number]];
 
   // nextOpenTimestamp(depositDate=Sunday) == monday morning. 
   const settledDate = DateTime.fromMillis(calledTimestamp);

--- a/libs/tx-deposit/src/graph.manual.test.ts
+++ b/libs/tx-deposit/src/graph.manual.test.ts
@@ -22,11 +22,12 @@ const createDate = DateTime.now()
 // The deposit happened on sunday
 const depositDate = createDate.plus({ days: 1 });
 const depositAmount = new Decimal(100);
+const processingDate = depositDate.plus({ day: 1 });
 
 beforeEach(async () => {
   await FirestoreInit();
   // It's currently monday at noon when we are processing this
-  jest.setSystemTime(depositDate.plus({ day: 1 }).toJSDate());
+  jest.setSystemTime(processingDate.toJSDate());
   jest.clearAllMocks();
 });
 
@@ -43,7 +44,7 @@ it('manual deposit uses the deposit date for conversion, not the action creation
     data: {
       initial: { amount: depositAmount, type: 'other' },
       initialId: 'test-manual-1',
-      date: createDate,  // action created Sunday; deposit happened Wednesday
+      date: createDate,
     },
     history: [],
     doc: getFirestore().doc('/Buy/test-manual-1') as unknown as BuyAction['doc'],
@@ -56,7 +57,7 @@ it('manual deposit uses the deposit date for conversion, not the action creation
   const finalState = getCurrentState(container);
   expect(finalState.name).toBe('complete');
 
-  // toCoin must have fetched the rate using the deposit date, not the action creation date.
+  // toCoin must have fetched the rate using the nextOpenTimestamp (monday 9:32)
   expect(getSingleSpy).toHaveBeenCalledTimes(1);
   const [[, calledTimestamp]] = getSingleSpy.mock.calls as [[number, number]];
 

--- a/libs/tx-deposit/src/graph.manual.test.ts
+++ b/libs/tx-deposit/src/graph.manual.test.ts
@@ -6,6 +6,8 @@ import Decimal from 'decimal.js-light';
 import { BuyAction } from '@thecointech/broker-db';
 import { getSigner } from '@thecointech/signers';
 import { GetRatesApi } from '@thecointech/apis/pricing';
+import { manual } from './graph.manual';
+import { StateMachineProcessor, getCurrentState } from '@thecointech/tx-statemachine';
 
 jest.useFakeTimers();
 
@@ -29,9 +31,6 @@ beforeEach(async () => {
 });
 
 it('manual deposit uses the deposit date for conversion, not the action creation date', async () => {
-  const { manual } = await import('./graph.manual');
-  const { StateMachineProcessor, getCurrentState } = await import('@thecointech/tx-statemachine');
-
   const deposit = {
     fiat: depositAmount,
     meta: 'test-deposit',

--- a/libs/tx-deposit/src/index.test.ts
+++ b/libs/tx-deposit/src/index.test.ts
@@ -1,4 +1,0 @@
-
-it.skip('needs tests written', () => {
-
-})

--- a/libs/tx-deposit/src/transitions/depositFiat.ts
+++ b/libs/tx-deposit/src/transitions/depositFiat.ts
@@ -38,7 +38,6 @@ async function doDeposit(container: BuyActionContainer) {
     return {
       fiat: new Decimal(etransfer.cad),
       meta: result.confirmation.toString(),
-      date: DateTime.now(),
     }
   }
   catch (err) {

--- a/libs/tx-etransfer/src/graph.test.ts
+++ b/libs/tx-etransfer/src/graph.test.ts
@@ -20,8 +20,9 @@ const bank = await RbcApi.create();
 const sendETransferSpy = jest.spyOn(bank, 'sendETransfer');
 
 // Action created Saturday noon, 4 weeks ago
-const createDate = DateTime.now()
-  .minus({ weeks: 4, days: DateTime.now().weekday + 1 })
+const now = DateTime.now();
+const createDate = now
+  .minus({ weeks: 4, days: now.weekday + 1 })
   .set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
 
 // Process on Monday afternoon
@@ -90,9 +91,7 @@ it('etransfer sell: happy path reaches complete', async () => {
 
 it('etransfer sell: returned transfer triggers revert to coin', async () => {
   // Simulate the e-transfer being returned: waitETransfer produces the "etransfer: returned" error
-  // by running to eTransferSent then injecting an error state manually via breakpoint + history
-  // Instead: we rely on the graph reaching eTransferComplete with error in history.
-  // The simplest approach: break at eTransferSent, inject error into history, then resume.
+  // Seed with history for a returned transfer (as we don't currently have an automated way to trigger this)
 
   // Revert on a Sunday.
   const revertTime = processingTime.plus({ weeks: 2, days: 6 });

--- a/libs/tx-etransfer/src/graph.test.ts
+++ b/libs/tx-etransfer/src/graph.test.ts
@@ -1,0 +1,166 @@
+import { jest } from '@jest/globals';
+import { init as FirestoreInit, getFirestore } from '@thecointech/firestore';
+import { ContractCore } from '@thecointech/contract-core';
+import { DateTime } from 'luxon';
+import Decimal from 'decimal.js-light';
+import { SellAction } from '@thecointech/broker-db';
+import { getSigner } from '@thecointech/signers';
+import { GetRatesApi } from '@thecointech/apis/pricing';
+import { RbcApi } from '@thecointech/rbcapi';
+import type { ETransferPacket } from '@thecointech/types';
+import { graph } from './graph';
+import { StateMachineProcessor, getCurrentState } from '@thecointech/tx-statemachine';
+
+jest.useFakeTimers();
+
+const ratesApi = GetRatesApi();
+const getSingleSpy = jest.spyOn(ratesApi, 'getSingle');
+
+const bank = await RbcApi.create();
+const sendETransferSpy = jest.spyOn(bank, 'sendETransfer');
+
+// Action created Saturday noon, 4 weeks ago
+const createDate = DateTime.now()
+  .minus({ weeks: 4, days: DateTime.now().weekday + 1 })
+  .set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+
+// Process on Monday afternoon
+const processingTime = createDate.plus({ days: 2 }).set({ hour: 14, minute: 0, second: 0, millisecond: 0 });
+
+const sellAmount = new Decimal(100000000);
+const userAddress = '0x0000000000000000000000000000000000000001';
+
+// Pre-decrypted instructions passed directly to avoid crypto in tests
+const instructions: ETransferPacket = {
+  email: 'user@example.com',
+  question: 'What is the answer?',
+  answer: 'forty-two',
+};
+
+beforeEach(async () => {
+  await FirestoreInit();
+  jest.clearAllMocks();
+});
+
+it('etransfer sell: happy path reaches complete', async () => {
+  jest.setSystemTime(processingTime.toJSDate());
+
+  const action: SellAction = {
+    address: userAddress,
+    type: 'Sell',
+    data: {
+      initial: {
+        transfer: {
+          chainId: 1,
+          from: userAddress,
+          to: process.env.WALLET_BrokerCAD_ADDRESS!,
+          value: sellAmount.toNumber(),
+          fee: 0,
+          timestamp: createDate.toMillis(),
+          signature: '',
+        },
+        instructionPacket: { encryptedPacket: '', version: '' },
+        signature: '',
+      },
+      initialId: 'test-sell-1',
+      date: createDate,
+    },
+    history: [],
+    doc: getFirestore().doc('/Sell/test-sell-1') as unknown as SellAction['doc'],
+  };
+
+  const contract = await ContractCore.connect(await getSigner("BrokerCAD"));
+  const processor = new StateMachineProcessor(graph, contract, bank);
+
+  const container = await processor.execute(instructions, action);
+  const finalState = getCurrentState(container);
+  expect(finalState.name).toBe('complete');
+
+  // depositCoin (tcReady) converts coin to fiat — getSingle called once for toFiat
+  expect(getSingleSpy).toHaveBeenCalledTimes(1);
+
+  // sendETransfer was called once with the fiat amount
+  expect(sendETransferSpy).toHaveBeenCalledTimes(1);
+
+  // Final state: fiat and coin are zeroed out
+  expect(finalState.data.coin?.isZero()).toBeTruthy();
+  expect(finalState.data.fiat?.isZero()).toBeTruthy();
+});
+
+
+it('etransfer sell: returned transfer triggers revert to coin', async () => {
+  // Simulate the e-transfer being returned: waitETransfer produces the "etransfer: returned" error
+  // by running to eTransferSent then injecting an error state manually via breakpoint + history
+  // Instead: we rely on the graph reaching eTransferComplete with error in history.
+  // The simplest approach: break at eTransferSent, inject error into history, then resume.
+
+  // Revert on a Sunday.
+  const revertTime = processingTime.plus({ weeks: 2, days: 6 });
+  jest.setSystemTime(revertTime.plus({ days: 1 }).toJSDate());
+
+  const action: SellAction = {
+    address: userAddress,
+    type: 'Sell',
+    data: {
+      initial: {
+        transfer: {
+          chainId: 1,
+          from: userAddress,
+          to: '0x0000000000000000000000000000000000000002',
+          value: sellAmount.toNumber(),
+          fee: 0,
+          timestamp: createDate.toMillis(),
+          signature: '',
+        },
+        instructionPacket: { encryptedPacket: '', version: '' },
+        signature: '',
+      },
+      initialId: 'test-sell-revert',
+      date: createDate,
+    },
+    history: [],
+    doc: getFirestore().doc('/Sell/test-sell-revert') as unknown as SellAction['doc'],
+  };
+
+  // Seed action.history so the processor replays up through eTransferSent,
+  // then hits the injected waitETransfer error and routes to the revert chain.
+  // We need realistic delta shapes for the transitions being replayed.
+  const fiatAmount = new Decimal(50);
+  action.history = [
+    // preTransfer (initial -> tcReady)
+    { type: 'preTransfer', created: processingTime },
+    // depositCoin (tcReady -> tcWaiting): coin deposited (at whatever exchange rate that is)
+    { type: 'depositCoin', created: processingTime, coin: fiatAmount.times(40000) },
+    // waitCoin (tcWaiting -> tcResult)
+    { type: 'waitCoin', created: processingTime },
+    // toFiat (tcResult -> converted): coin -> fiat
+    { type: 'toFiat', created: processingTime, coin: new Decimal(0), fiat: fiatAmount, date: processingTime },
+    // preTransfer (converted -> eTransferReady)
+    { type: 'preTransfer', created: processingTime },
+    // sendETransfer (eTransferReady -> eTransferSent): fiat zeroed, date set
+    { type: 'sendETransfer', created: processingTime, meta: '9999', fiat: new Decimal(0) },
+    // waitETransfer (eTransferSent -> eTransferComplete): returned error with date
+    { type: 'waitETransfer', created: processingTime, error: 'etransfer: returned', date: revertTime },
+  ];
+
+  const contract = await ContractCore.connect(await getSigner("BrokerCAD"));
+  const processor = new StateMachineProcessor(graph, contract, bank);
+
+  const container = await processor.execute(instructions, action);
+  const finalState = getCurrentState(container);
+  expect(finalState.name).toBe('complete');
+
+  // toCoin was called during the revert (getSingle called once for the revert conversion)
+  expect(getSingleSpy).toHaveBeenCalledTimes(1);
+  const [[, calledTimestamp]] = getSingleSpy.mock.calls as [[number, number]];
+
+  // nextOpenTimestamp(depositDate=Sunday) == monday morning. 
+  const settledDate = DateTime.fromMillis(calledTimestamp);
+  expect(settledDate.weekday).toBe(1); // Monday
+  expect(settledDate.hour).toBe(9);
+  expect(settledDate.minute).toBe(32);
+
+  // End state: coin and fiat both zero after sendCoin
+  expect(finalState.data.coin?.isZero()).toBeTruthy();
+  expect(finalState.data.fiat?.isZero()).toBeTruthy();
+});

--- a/libs/tx-etransfer/src/graph.ts
+++ b/libs/tx-etransfer/src/graph.ts
@@ -57,7 +57,7 @@ export const graph : StateGraph<States, "Sell"> = {
   eTransferSent: {
     // An error with sending the transfer - admin needs to figure out what went wrong here.
     onError: transitionTo<States>(core.requestManual, "error"),
-    // wait for user to deposit it before move forward to `eTransferResult`
+    // wait for user to deposit it before move forward to `eTransferComplete`
     next: transitionTo<States, "Sell">(eTransfer.waitETransfer, "eTransferComplete"),
   },
   // Transfer has been deposited/or failed.
@@ -84,6 +84,7 @@ export const graph : StateGraph<States, "Sell"> = {
     next: transitionTo<States, "Sell">(core.sendCoin, "revertWaiting"),
   },
   revertWaiting: {
+    onError: transitionTo<States>(core.requestManual, "error"),
     next: transitionTo<States, "Sell">(core.waitCoin, "revertComplete"),
   },
   revertComplete: {

--- a/libs/tx-etransfer/src/graph.ts
+++ b/libs/tx-etransfer/src/graph.ts
@@ -12,14 +12,18 @@ type States =
   "converted" |
 
   "eTransferReady" |
-  "eTransferResult" |
+  "eTransferSent" |
+  "eTransferComplete" |
+
+  "revertBegin" |
+  "revertConverted" |
+  "revertReady" |
+  "revertWaiting" |
+  "revertComplete" |
 
   "error" |
   "complete" |
   "cancelled";
-//"refunding" |
-//"refundReady";
-
 
 export const graph : StateGraph<States, "Sell"> = {
   initial: {
@@ -45,20 +49,49 @@ export const graph : StateGraph<States, "Sell"> = {
     next: transitionTo<States>(core.preTransfer, "eTransferReady"),
   },
 
+  // Before sending eTransfer
   eTransferReady: {
-    next: transitionTo<States, "Sell">(eTransfer.sendETransfer, "eTransferResult"),
+    next: transitionTo<States, "Sell">(eTransfer.sendETransfer, "eTransferSent"),
   },
-  eTransferResult: {
+  // The transfer has been sent
+  eTransferSent: {
+    // An error with sending the transfer - admin needs to figure out what went wrong here.
+    onError: transitionTo<States>(core.requestManual, "error"),
+    // wait for user to deposit it before move forward to `eTransferResult`
+    next: transitionTo<States, "Sell">(eTransfer.waitETransfer, "eTransferComplete"),
+  },
+  // Transfer has been deposited/or failed.
+  eTransferComplete: {
+    // Waiting went wrong (timed out?)
+    onError: transitionTo<States, "Sell">(eTransfer.handleWaitError, "revertBegin"),
+    // If deposited, mark complete.
+    next: transitionTo<States>(core.markComplete, "complete"),
+  },
+
+  // Revert reverse the coin transaction "only"
+  revertBegin: {
+    // handleWaitError didn't find an error it could handle, pass back to human.
+    onError: transitionTo<States>(core.requestManual, "error"),
+    // Otherwise, transfer away.
+    next: transitionTo<States, "Sell">(core.toCoin, "revertConverted"),
+  },
+  revertConverted: {
+    onError: transitionTo<States>(core.requestManual, "error"),
+    next: transitionTo<States, "Sell">(core.preTransfer, "revertReady"),
+  },
+  revertReady: {
+    onError: transitionTo<States>(core.requestManual, "error"),
+    next: transitionTo<States, "Sell">(core.sendCoin, "revertWaiting"),
+  },
+  revertWaiting: {
+    next: transitionTo<States, "Sell">(core.waitCoin, "revertComplete"),
+  },
+  revertComplete: {
     onError: transitionTo<States>(core.requestManual, "error"),
     next: transitionTo<States>(core.markComplete, "complete"),
   },
 
-  // refunding: {
-  //   next: transitionTo(noop, "complete"),
-  // },
-  // refundReady: {
-  //   next: transitionTo(noop, "complete"),
-  // },
+
   error: {
     next: core.manualOverride,
   },

--- a/libs/tx-etransfer/src/transitions/handleWaitError.ts
+++ b/libs/tx-etransfer/src/transitions/handleWaitError.ts
@@ -1,0 +1,42 @@
+import { makeTransition } from '@thecointech/tx-statemachine';
+import Decimal from 'decimal.js-light';
+
+//
+// Handle an error from waiting for an e-transfer deposit.
+// If the e-transfer was returned, restore the fiat balance so the graph
+// can convert it back to coin and send it back to the user.
+export const handleWaitError = makeTransition<"Sell">("handleWaitError", async (container) => {
+
+  // The only error we can handle automatically is the "etransfer: returned" error
+  const lastTransition = container.history?.at(-1);
+
+  const lastCoin = lastTransition?.data.coin;
+  if (!lastCoin || !lastCoin.isZero()) {
+    return { error: "Last state coin must be zero" }
+  }
+
+  const { error, date } = lastTransition.delta;
+  if (!date) {
+    return { error: "Wait error missing date: cannot handle automatically" }
+  }
+  if (error !== "etransfer: returned") {
+    return { error: "Unexpected error: cannot handle automatically" }
+  }
+
+  // Handle the error.  For now, we assume a human admin has re-claimed the money.
+  const fiatTransitions = container.history.filter(d => d.delta.fiat && d.delta.fiat.gt(0));
+  if (fiatTransitions.length !== 1) {
+    return { error: `Unexpected fiat transactions in history: found ${fiatTransitions.length}, expected 1` }
+  }
+
+  // This was how much was initially deposited.
+  const fiat = fiatTransitions[0].delta.fiat;
+
+  // Ok, this resets this transaction back to having this amount
+  return {
+    error: "",
+    coin: new Decimal(0),
+    fiat,
+    date,
+  };
+});

--- a/libs/tx-etransfer/src/transitions/handleWaitError.ts
+++ b/libs/tx-etransfer/src/transitions/handleWaitError.ts
@@ -1,5 +1,4 @@
 import { makeTransition } from '@thecointech/tx-statemachine';
-import Decimal from 'decimal.js-light';
 
 //
 // Handle an error from waiting for an e-transfer deposit.
@@ -35,7 +34,6 @@ export const handleWaitError = makeTransition<"Sell">("handleWaitError", async (
   // Ok, this resets this transaction back to having this amount
   return {
     error: "",
-    coin: new Decimal(0),
     fiat,
     date,
   };

--- a/libs/tx-etransfer/src/transitions/index.ts
+++ b/libs/tx-etransfer/src/transitions/index.ts
@@ -1,2 +1,4 @@
 export * from './sendETransfer';
 export * from './etransferCancelled';
+export * from './waitETransfer';
+export * from './handleWaitError';

--- a/libs/tx-etransfer/src/transitions/waitETransfer.ts
+++ b/libs/tx-etransfer/src/transitions/waitETransfer.ts
@@ -1,0 +1,9 @@
+import { makeTransition } from '@thecointech/tx-statemachine';
+
+//
+// Wait for the e-transfer to be deposited.
+export const waitETransfer = makeTransition<"Sell">("waitETransfer", async () => {
+  // In the future, this will check the e-transfer status somehow,
+  // It should not succeed until the e-transfer is deposited by the user.
+  return {};
+});

--- a/libs/tx-etransfer/src/transitions/waitETransfer.ts
+++ b/libs/tx-etransfer/src/transitions/waitETransfer.ts
@@ -5,5 +5,6 @@ import { makeTransition } from '@thecointech/tx-statemachine';
 export const waitETransfer = makeTransition<"Sell">("waitETransfer", async () => {
   // In the future, this will check the e-transfer status somehow,
   // It should not succeed until the e-transfer is deposited by the user.
+  // For now, just assume every transfer succeeds.
   return {};
 });

--- a/libs/tx-statemachine/src/index.ts
+++ b/libs/tx-statemachine/src/index.ts
@@ -105,7 +105,7 @@ export function transitionTo<States extends string, Type extends ActionType=Acti
 // Every graph execution starts in the initial state.
 const initialState = <States extends string>(date: DateTime): StateSnapshot<States> => ({
   name: "initial" as States,
-  data: {},
+  data: { date },
   delta: {
     type: "no prior state",
     created: date,

--- a/libs/tx-statemachine/src/transitions/depositCoin.test.ts
+++ b/libs/tx-statemachine/src/transitions/depositCoin.test.ts
@@ -81,7 +81,7 @@ const getContainer = async (value: number, balance: number, fee: number): Promis
         type: "preTransfer",
         created: now,
       },
-      data: {},
+      data: { date: now },
     }],
     instructions,
   };

--- a/libs/tx-statemachine/src/transitions/depositCoin.ts
+++ b/libs/tx-statemachine/src/transitions/depositCoin.ts
@@ -1,10 +1,10 @@
-import { AnyActionContainer, getCurrentState, TransitionCallback, TypedActionContainer } from "../types";
+import { AnyActionContainer, getCurrentState, TransitionCallback } from "../types";
 import { verifyPreTransfer } from "./verifyPreTransfer";
 import { TransactionResponse } from 'ethers';
 import { toDelta } from './coinUtils';
 import { log } from '@thecointech/logging';
 import { makeTransition  } from '../makeTransition';
-import type { CertifiedTransferRequest, UberTransfer } from '@thecointech/types';
+import type { CertifiedTransferRequest } from '@thecointech/types';
 import { isCertTransfer } from '@thecointech/utilities/VerifiedTransfer';
 
 // this deposit can operate on both bill & sell types.
@@ -25,9 +25,11 @@ const doDepositCoin: TransitionCallback<BSActionTypes> = async (container) => {
   }
 
   const request = container.action.data.initial;
-  return isCertTransfer(request.transfer)
-    ? await depositCertifiedTransfer(container, request.transfer)
-    : await depositUberTransfer(container, request.transfer);
+  // Uber transfers require the specialized uberGraph; do not process them here
+  if (!isCertTransfer(request.transfer)) {
+    throw new Error("Uber transfer cannot be processed by depositCoin; use uberDepositCoin");
+  }
+  return await depositCertifiedTransfer(container, request.transfer);
 }
 
 const depositCertifiedTransfer = async (container: AnyActionContainer, transfer: CertifiedTransferRequest) => {
@@ -45,23 +47,6 @@ const depositCertifiedTransfer = async (container: AnyActionContainer, transfer:
 
   log.debug({address: from, amount: value.toString()}, `CertTransfer of {amount} from {address}`);
   const tx: TransactionResponse = await tc.certifiedTransfer(chainId, from, to, value, fee, timestamp, signature);
-  return toDelta(tx);
-}
-
-const depositUberTransfer = async (container: TypedActionContainer<BSActionTypes>, transfer: UberTransfer) => {
-  const { chainId, from, to, amount, currency, signature, signedMillis, transferMillis } = transfer;
-  const tc = container.contract;
-
-  // Check balance (so we don't waste gas on a clearly-won't-work tx below)
-  // We check balance in the initial steps as well, but this is for scenarios
-  // where the deposit is delayed for any reason (eg - server crash etc);
-  log.warn("DepositUberTransfer needs safeguards");
-  // const balance = await tc.pl_balanceOf(from);
-  // if (balance.lte(amount))
-  //   return { error: 'Insufficient funds'};
-
-  log.debug({address: from, amount: amount.toString()}, 'UberTransfer of {amount} from {address}');
-  const tx: TransactionResponse = await tc.uberTransfer(chainId, from, to, amount, currency, transferMillis, signedMillis, signature);
   return toDelta(tx);
 }
 

--- a/libs/tx-statemachine/src/transitions/sendCoin.ts
+++ b/libs/tx-statemachine/src/transitions/sendCoin.ts
@@ -1,12 +1,10 @@
 import { log } from "@thecointech/logging";
 import Decimal from 'decimal.js-light';;
-import { AnyActionContainer, getCurrentState, TransitionCallback } from "../types";
+import { getCurrentState, TransitionCallback } from "../types";
 import { makeTransition  } from '../makeTransition';
 import { verifyPreTransfer } from "./verifyPreTransfer";
 import { DateTime } from "luxon";
-import { toCoin } from "./toCoin";
 import { toDelta } from './coinUtils';
-import { last } from '@thecointech/utilities';
 import type { TheCoin } from '@thecointech/contract-core';
 
 //
@@ -23,8 +21,8 @@ const doSendCoin: TransitionCallback = async (container) => {
     return { error: 'Cannot send coin, state has no value' }
   }
 
-  const settledDate = findSettledDate(container);
-  var tx = await startTheTransfer(container.action.address, currentState.data.coin, settledDate, container.contract);
+  const { coin, date } = currentState.data;
+  var tx = await startTheTransfer(container.action.address, coin, date, container.contract);
 
   // We only start the transfer (do not wait for completion).
   // If completion is required add 'waitCoin' transition.
@@ -41,7 +39,3 @@ async function startTheTransfer(address: string, value: Decimal, settled: DateTi
   );
 }
 
-function findSettledDate(container: AnyActionContainer) {
-  const settlements = container.history.filter(t => t.delta.type == toCoin.transitionName);
-  return last(settlements)?.delta.date ?? container.action.data.date;
-}

--- a/libs/tx-statemachine/src/transitions/toCoin.test.ts
+++ b/libs/tx-statemachine/src/transitions/toCoin.test.ts
@@ -92,6 +92,58 @@ it ("correctly converts CertifiedTransfer", async () => {
   expect(getSingle).toHaveBeenCalledWith(124, mondayMorning.toMillis());
 })
 
+it ("uses state date, not action date, when converting", async () => {
+  // Simulate the revert flow: action was created at `now` but handleWaitError
+  // set state.data.date to a later date (the day the e-Transfer was returned).
+  const returnDate = now.plus({ days: 7 }); // next Sunday
+  const sale = await BuildVerifiedAction(
+    instructions,
+    signer,
+    "0x0000000000000000000000000000000000000000",
+    amount.toNumber(),
+    0,
+  );
+
+  const action = await createAction(signer.address, "Bill", {
+    initial: sale,
+    date: now,            // action was created at `now`
+    initialId: sale.signature
+  });
+
+  const container: BillActionContainer = {
+    action,
+    bank: {} as any,
+    contract: await ContractCore.get(),
+    history: [
+      {
+        name: "mocked",
+        data: {
+          coin: amount,
+          date: returnDate,  // state date has been updated to the return date
+        },
+        delta: {
+          created: now,
+          type: "mocked",
+        }
+      }
+    ],
+    instructions,
+  };
+
+  const { toFiat } = await import('./toCoin');
+  const nopass = await toFiat(container);
+  expect(nopass).toBeNull();
+
+  // Advance past the return date so conversion is allowed
+  jest.setSystemTime(returnDate.plus({ day: 1 }).toJSDate());
+  const result = await toFiat(container);
+  expect(result?.fiat?.gt(0)).toBeTruthy();
+
+  // nextOpenTimestamp(returnDate) = Monday after returnDate at 9:32am
+  const expectedOpen = returnDate.plus({ days: 1 }).set({ hour: 9, minute: 32, second: 0 });
+  expect(getSingle).toHaveBeenCalledWith(124, expectedOpen.toMillis());
+})
+
 // Data
 
 // Now is 12pm sunday last sunday
@@ -121,6 +173,7 @@ const getContainer = async (sale: CertifiedTransfer | UberTransferAction) : Prom
         name: "mocked",
         data: {
           coin: amount,
+          date: now,
         },
         delta: {
           created: now,

--- a/libs/tx-statemachine/src/transitions/toCoin.ts
+++ b/libs/tx-statemachine/src/transitions/toCoin.ts
@@ -72,7 +72,8 @@ async function getConvertAt(date: DateTime) {
 
 async function getSettledAt(container: TypedActionContainer<XferAction>) {
   const action = container.action.data.initial;
-  const requestDate = container.action.data.date;
+  const currentState = getCurrentState(container);
+  const requestDate = currentState.data.date;
 
   if (isSellAction(action)) {
     if (isUberTransfer(action.transfer)) {

--- a/libs/tx-statemachine/src/transitions/uberClearPending.ts
+++ b/libs/tx-statemachine/src/transitions/uberClearPending.ts
@@ -32,11 +32,7 @@ const doClearPending: TransitionCallback<BSActionTypes> = async (container) => {
   // UberTransfer completed immediately.  In this case, there is no need to do anything
   const currentState = getCurrentState(container)
   if (currentState.data.coin?.isPositive()) {
-    log.error(
-      { initialId: container.action.data.initialId },
-      "Cannot clear pending, already have coin balance"
-    )
-    return {};
+    return { error: "Cannot clear pending, already have coin balance" };
   }
 
   const { from, to, transferMillis } = request.transfer;

--- a/libs/tx-statemachine/src/transitions/uberDepositCoin.ts
+++ b/libs/tx-statemachine/src/transitions/uberDepositCoin.ts
@@ -3,6 +3,7 @@ import { verifyPreTransfer } from "./verifyPreTransfer";
 import { TransactionResponse } from 'ethers';
 import { toDelta } from './coinUtils';
 import { log } from '@thecointech/logging';
+import { DateTime } from 'luxon';
 import { makeTransition  } from '../makeTransition';
 import type { UberTransfer } from '@thecointech/types';
 import { isCertTransfer } from '@thecointech/utilities/VerifiedTransfer';
@@ -53,6 +54,9 @@ const depositUberTransfer = async (container: TypedActionContainer<BSActionTypes
     {address: from, nonce: tx.nonce, initialId: container.action.data.initialId },
     'UberTransfer complete with nonce: {nonce}'
   );
-  return toDelta(tx);
+  return {
+    ...toDelta(tx),
+    date: DateTime.fromMillis(transferMillis),
+  };
 }
 

--- a/libs/tx-statemachine/src/transitions/uberDepositCoin.ts
+++ b/libs/tx-statemachine/src/transitions/uberDepositCoin.ts
@@ -54,9 +54,12 @@ const depositUberTransfer = async (container: TypedActionContainer<BSActionTypes
     {address: from, nonce: tx.nonce, initialId: container.action.data.initialId },
     'UberTransfer complete with nonce: {nonce}'
   );
-  return {
-    ...toDelta(tx),
-    date: DateTime.fromMillis(transferMillis),
-  };
+  const delta = toDelta(tx);
+  return delta.error 
+    ? delta 
+    : {
+      date: DateTime.fromMillis(transferMillis),
+      ...delta,
+    };
 }
 

--- a/libs/tx-statemachine/src/transitions/uberWaitPending.ts
+++ b/libs/tx-statemachine/src/transitions/uberWaitPending.ts
@@ -4,9 +4,8 @@ import { isCertTransfer } from '@thecointech/utilities/VerifiedTransfer';
 // this deposit can operate on both bill & sell types.
 type BSActionTypes = "Bill"|"Sell";
 //
-// Remove from incomplete listings.
+// Wait until an uberTransaction transfer date has passed
 export const uberWaitPending = makeTransition<BSActionTypes>("uberWaitPending", async (container) => {
-  // Remove from our list of active transactions
   const request = container.action.data.initial;
   if (isCertTransfer(request.transfer)) {
     throw new Error("Cannot deposit certified transfer");

--- a/libs/tx-statemachine/src/transitions/waitCoin.ts
+++ b/libs/tx-statemachine/src/transitions/waitCoin.ts
@@ -59,7 +59,7 @@ export function updateCoinBalance(container: AnyActionContainer, receipt: Transa
   // Only use the transfer from the current user to us(?)
   const legalAddresses = [
     NormalizeAddress(process.env.WALLET_BrokerCAD_ADDRESS!),
-    container.action.address,
+    NormalizeAddress(container.action.address),
   ]
   const [transfer, ...rest] = exactTransfers.filter(t => (
     legalAddresses.includes(NormalizeAddress(t?.args.from)) &&
@@ -72,8 +72,8 @@ export function updateCoinBalance(container: AnyActionContainer, receipt: Transa
     // (It is legal to have 0 transfers with UberConverter)
     if (exactTransfers.length !== 0) {
       log.error(
-        { initialId: container.action.data.initialId, hash: receipt.hash },
-        "ExactTransfer found for {initialId} in {hash}, but it does not match Broker address"
+        { hash: receipt.hash },
+        "ExactTransfer found in {hash}, but it does not match Broker address"
       );
       // We have no idea what is going on here, so hard-stop
       throw new Error("ExactTransfer not as expected");
@@ -94,9 +94,10 @@ export function updateCoinBalance(container: AnyActionContainer, receipt: Transa
     balance = balance.minus(transfer.args.amount.toString());
   }
   else {
-    log.error({ initialId: container.action.data.initialId, hash: receipt.hash },
-      "Could not find address for {initialId} in {hash}")
-    throw new Error("Missing address, cannot")
+    log.error({ from: transfer.args.from, to: transfer.args.to, hash: receipt.hash },
+      "Neither from nor to addresses match container address in {hash}"
+    );
+    throw new Error("Neither from nor to addresses match container address in {hash}, cannot update balance");
   }
   return { coin: balance };
 }

--- a/libs/tx-statemachine/src/transitions/waitCoin.ts
+++ b/libs/tx-statemachine/src/transitions/waitCoin.ts
@@ -97,7 +97,7 @@ export function updateCoinBalance(container: AnyActionContainer, receipt: Transa
     log.error({ from: transfer.args.from, to: transfer.args.to, hash: receipt.hash },
       "Neither from nor to addresses match container address in {hash}"
     );
-    throw new Error("Neither from nor to addresses match container address in {hash}, cannot update balance");
+    throw new Error(`Neither from nor to addresses match container address in ${receipt.hash}, cannot update balance`);
   }
   return { coin: balance };
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "dump-firestore": "run-env cfg=devlive ./dumpFirestore.ts",
     "cancel-tx": "run-env cfg=prod ./transactions/cancelTx.ts",
-    "pullRates": "cross-env URL_SEQ_LOGGING=false LOG_NAME=PullRates run-env cfg=prodtest ./pullRates.ts",
-    "showBalances": "run-env cfg=prod ./showBalances.ts",
-    "initDemoAccount": "run-env cfg=prodtest ./initDemoAccount.ts",
-    "transfer": "cross-env URL_SEQ_LOGGING=false run-env cfg=prod ./transactions/manualTransfer.ts",
-    "revert": "cross-env URL_SEQ_LOGGING=false run-env cfg=prod ./transactions/revertTransfer.ts"
+    "pullRates": "yarn _run cfg=prodtest ./pullRates.ts",
+    "showBalances": "yarn _run cfg=prod ./showBalances.ts",
+    "showAccount": "yarn _run cfg=prod ./showAccount.ts",
+    "initDemoAccount": "yarn _run cfg=prodtest ./initDemoAccount.ts",
+    "transfer": "yarn _run cfg=prod ./transactions/manualTransfer.ts",
+    "revert": "yarn _run cfg=prod ./transactions/revertTransfer.ts",
+    "_run": "cross-env URL_SEQ_LOGGING=false TC_LOG_FOLDER=false run-env --"
   },
   "devDependencies": {
     "@thecointech/setenv": "^0.6.3",

--- a/tools/showAccount.ts
+++ b/tools/showAccount.ts
@@ -28,12 +28,14 @@ async function getRateForDate(date: DateTime) {
       rate = fetched;
       fetchedRates.push(rate);
     }
+    else {
+      throw new Error(`No rate found for ${date.toFormat("yyyy-MM-dd")}`);
+    }
   }
-  return rate ? rate.sell * rate.fxRate : 0;
+  return rate.sell * rate.fxRate;
 }
 
-const currentRate = await fetchRate();
-const currentRateCAD = currentRate ? currentRate.sell * currentRate.fxRate : 0;
+const currentRateCAD = await getRateForDate(DateTime.now());
 
 calculateTxBalances(balance, history);
 
@@ -59,5 +61,5 @@ console.log(`\nAccount history for ${address} (${rows.length} transactions):\n`)
 console.table(rows);
 
 const currentBalanceCoin = toHuman(Number(balance), true);
-const currentBalanceCAD = currentRateCAD > 0 ? toHuman(Number(balance) * currentRateCAD, true) : 0;
+const currentBalanceCAD = toHuman(Number(balance) * currentRateCAD, true);
 console.log(`\nCurrent balance: ${currentBalanceCoin.toFixed(2)} Coin (${currentBalanceCAD.toFixed(2)} CAD)`);

--- a/tools/showAccount.ts
+++ b/tools/showAccount.ts
@@ -1,0 +1,63 @@
+import { ContractCore } from "@thecointech/contract-core";
+import { calculateTxBalances, loadAndMergeHistory } from "@thecointech/tx-blockchain";
+import { fetchRate } from "@thecointech/fx-rates";
+import { toHuman } from "@thecointech/utilities";
+import { DateTime } from "luxon";
+
+const address = process.argv[2];
+if (!address) {
+  throw new Error("Usage: showAccount <address>");
+}
+
+const tc = await ContractCore.get();
+const balance = await tc.balanceOf(address);
+const history = await loadAndMergeHistory(0, tc, address);
+
+if (history.length === 0) {
+  console.log(`No transaction history found for ${address}`);
+  process.exit(0);
+}
+
+const fetchedRates: Array<{ validFrom: number; validTill: number; sell: number; fxRate: number }> = [];
+async function getRateForDate(date: DateTime) {
+  const ts = date.toMillis();
+  let rate = fetchedRates.find(r => r.validFrom <= ts && r.validTill > ts);
+  if (!rate) {
+    const fetched = await fetchRate(date.toJSDate());
+    if (fetched) {
+      rate = fetched;
+      fetchedRates.push(rate);
+    }
+  }
+  return rate ? rate.sell * rate.fxRate : 0;
+}
+
+const currentRate = await fetchRate();
+const currentRateCAD = currentRate ? currentRate.sell * currentRate.fxRate : 0;
+
+calculateTxBalances(balance, history);
+
+const rows = [] as Array<{
+  date: string;
+  change: string;
+  balanceCoin: string;
+  balanceCAD: string;
+  txHash: string;
+}>;
+for (const tx of history) {
+  const rateCAD = await getRateForDate(tx.date);
+  rows.push({
+    date: tx.date.toFormat("yyyy-MM-dd HH:mm"),
+    change: `${toHuman(tx.change * rateCAD, true).toFixed(2)}`,
+    balanceCoin: `${toHuman(tx.balance, true).toFixed(2)}`,
+    balanceCAD: rateCAD > 0 ? `${toHuman(tx.balance * rateCAD, true).toFixed(2)}` : "N/A",
+    txHash: tx.txHash,
+  });
+}
+
+console.log(`\nAccount history for ${address} (${rows.length} transactions):\n`);
+console.table(rows);
+
+const currentBalanceCoin = toHuman(Number(balance), true);
+const currentBalanceCAD = currentRateCAD > 0 ? toHuman(Number(balance) * currentRateCAD, true) : 0;
+console.log(`\nCurrent balance: ${currentBalanceCoin.toFixed(2)} Coin (${currentBalanceCAD.toFixed(2)} CAD)`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line “account summary” view showing balances, transaction history, and CAD valuation.
  * Expanded e-transfer flows to progress through explicit sent/complete phases and support returned-transfer revert handling.

* **Bug Fixes**
  * Corrected conversion/settlement timing to consistently use the transaction state date (not the action creation date).
  * Updated successful payment/deposit responses to omit returned “now” timestamps and improved clearing/resetting of final coin/fiat balances.

* **Tests**
  * Added/updated Jest coverage for billing, e-transfer sell, and deposit graphs to verify happy paths and error/revert cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->