### PR TITLE
Tools/revert existing failed etransfer

### DIFF
--- a/tools/showAccount.ts
+++ b/tools/showAccount.ts
@@ -44,15 +44,25 @@ const rows = [] as Array<{
   change: string;
   balanceCoin: string;
   balanceCAD: string;
+  costBasis: string;
+  profit: string;
   txHash: string;
 }>;
+
+let costBasis = 0;
 for (const tx of history) {
   const rateCAD = await getRateForDate(tx.date);
+  const change = toHuman(tx.change * rateCAD, true).toFixed(2);
+  const balanceCAD = toHuman(tx.balance * rateCAD, true).toFixed(2);
+  costBasis += Number(change);
+  const profit = (Number(balanceCAD) - costBasis).toFixed(2);
   rows.push({
     date: tx.date.toFormat("yyyy-MM-dd HH:mm"),
-    change: `${toHuman(tx.change * rateCAD, true).toFixed(2)}`,
+    change: `${change}`,
     balanceCoin: `${toHuman(tx.balance, true).toFixed(2)}`,
-    balanceCAD: rateCAD > 0 ? `${toHuman(tx.balance * rateCAD, true).toFixed(2)}` : "N/A",
+    balanceCAD: balanceCAD?.toString() ?? "N/A",
+    costBasis: costBasis.toFixed(2),
+    profit: profit,
     txHash: tx.txHash,
   });
 }

--- a/tools/showAccount.ts
+++ b/tools/showAccount.ts
@@ -24,7 +24,7 @@ async function getRateForDate(date: DateTime) {
   let rate = fetchedRates.find(r => r.validFrom <= ts && r.validTill > ts);
   if (!rate) {
     const fetched = await fetchRate(date.toJSDate());
-    if (fetched) {
+    if (fetched?.fxRate) {
       rate = fetched;
       fetchedRates.push(rate);
     }
@@ -52,17 +52,17 @@ const rows = [] as Array<{
 let costBasis = 0;
 for (const tx of history) {
   const rateCAD = await getRateForDate(tx.date);
-  const change = toHuman(tx.change * rateCAD, true).toFixed(2);
-  const balanceCAD = toHuman(tx.balance * rateCAD, true).toFixed(2);
+  const change = toHuman(tx.change * rateCAD, true);
+  const balanceCAD = toHuman(tx.balance * rateCAD, true);
   costBasis += Number(change);
-  const profit = (Number(balanceCAD) - costBasis).toFixed(2);
+  const profit = (balanceCAD - costBasis);
   rows.push({
     date: tx.date.toFormat("yyyy-MM-dd HH:mm"),
-    change: `${change}`,
-    balanceCoin: `${toHuman(tx.balance, true).toFixed(2)}`,
-    balanceCAD: balanceCAD?.toString() ?? "N/A",
+    change: change.toFixed(2),
+    balanceCoin: toHuman(tx.balance, true).toFixed(2),
+    balanceCAD: balanceCAD.toFixed(2),
     costBasis: costBasis.toFixed(2),
-    profit: profit,
+    profit: profit.toFixed(2),
     txHash: tx.txHash,
   });
 }

--- a/tools/transactions/revertTransfer.ts
+++ b/tools/transactions/revertTransfer.ts
@@ -118,18 +118,20 @@ async function getUserAddress(hash: string) {
     throw new Error(`Transaction not found: ${hash}`);
   }
 
-  const exactTransfer = txReceipt.logs
+  const exactTransfers = txReceipt.logs
     .map(log => {
       try { return tcCore.interface.parseLog(log); }
       catch { return null; }
     })
-    .find(p => p?.name === "ExactTransfer");
+    .filter(p => p?.name === "ExactTransfer");
 
-  if (!exactTransfer) {
-    throw new Error(`No ExactTransfer event found in transaction ${hash}`);
+  if (exactTransfers.length !== 1) {
+    throw new Error(`${exactTransfers.length} ExactTransfer events found in transaction ${hash}`);
   }
+
+  const exactTransfer = exactTransfers[0];
   
-  return exactTransfer.args.from as string;
+  return exactTransfer!.args.from as string;
 }
 
 await init({ service: "BrokerServiceAccount" });

--- a/tools/transactions/revertTransfer.ts
+++ b/tools/transactions/revertTransfer.ts
@@ -1,72 +1,137 @@
-import { Wallet } from 'ethers';
-import { readFileSync } from 'fs';
-import { getSigner } from "@thecointech/signers";
 import { ContractCore } from "@thecointech/contract-core";
-import { fetchRate } from '@thecointech/fx-rates';
-import { toCoinDecimal } from '@thecointech/utilities';
-import Decimal from 'decimal.js-light';
+import { getActionsForAddress, storeTransition, type SellAction } from '@thecointech/broker-db';
+import { init, getFirestore } from '@thecointech/firestore';
 import { DateTime } from 'luxon';
-import type { XferRequest } from './types';
 
-// Read the same transfer file used by manualTransfer.ts
-const xferPath = process.argv[2];
-if (!xferPath) {
-  throw new Error("No transfer file specified");
+// Args - hash of transaction to revert, date revert happens on
+const hash = process.argv[2];
+const revertDate = process.argv[3];
+if (!hash) {
+  throw new Error("No transaction hash specified");
 }
-const xferRequest = JSON.parse(readFileSync(xferPath, 'utf-8')) as XferRequest;
-const signerRaw = readFileSync(xferRequest.wallet, 'utf-8');
-const password = await new Promise<string>(resolve => {
-  process.stdout.write('Wallet password: ');
-  process.stdin.once('data', data => resolve(data.toString().trim()));
-});
-const signer = Wallet.fromEncryptedJsonSync(signerRaw, password);
-const date = DateTime.fromSQL(xferRequest.date);
-
-const rate = await fetchRate(date.toJSDate());
-if (!rate) {
-  throw new Error("Failed to fetch rate");
+if (!revertDate) {
+  throw new Error("No revert date specified");
 }
-// revertTransfer requires THECOIN_ROLE (DEFAULT_ADMIN_ROLE)
-const owner = await getSigner("TheCoin");
-const contract = await ContractCore.connect(owner);
+const returnDate = DateTime.fromSQL(revertDate);
+if (!returnDate.isValid) {
+  throw new Error(`Invalid revert date: ${revertDate}`);
+}
 
-const transfers = xferRequest.transfers.map((t: { to: string; fiat: number }) => ({
-  from: t.to,
-  to: signer.address,
-  coin: toCoinDecimal(
-    new Decimal(t.fiat)
-      .div(rate.fxRate * rate.sell)
-  ),
-  fiat: t.fiat,
-}));
 
-for (const t of transfers) {
-  const amount = t.coin.toNumber();
-  const balanceFrom = await contract.balanceOf(t.from);
-  const balanceTo = await contract.balanceOf(t.to);
+async function main() {
+  const address = await getUserAddress(hash);
+  const action = await getUserAction(address, hash);
 
-  console.log(`\n--- Revert Transfer ---`);
-  console.log(`  From:   ${t.from} (balance: ${balanceFrom})`);
-  console.log(`  To:     ${t.to} (balance: ${balanceTo})`);
-  console.log(`  Amount: ${amount} (fiat: $${t.fiat})`);
+  if (!action) {
+    throw new Error(`No action found for address ${address} and hash ${hash}`);
+  }
 
+  const withFiat = action.history.map(delta => delta.fiat);
+  const amounts = withFiat.filter(f => f?.gt(0));
+  if (amounts.length != 1) {
+    throw new Error(`Expected exactly one fiat amount for action ${action.data.initialId}, got ${amounts.length}`);
+  }
+
+  const history = action.history.map(h => h.type);
+
+  console.log(`\n--- Revert ${action.type} Transfer ---`);
+  console.log(`  Hash:      ${hash}`);
+  console.log(`  From:      ${address}`);
+  console.log(`  On:        ${action.data.date.toSQLDate()}`);
+  console.log(`  Amount:    ${amounts[0]}`);
+  console.log(`  History:   ${history.join(", ")}`);
+
+  await checkProceed();
+
+  console.log("Reverting transfer...");
+  await insertReturnedETransfer(action, returnDate);
+  console.log("Done. The processor will now revert the e-Transfer back to coin.");
+}
+
+async function insertReturnedETransfer(action: SellAction, returnDate: DateTime) {
+  // Get the history subcollection docs
+  throw new Error("Check Implementation - this was created for a specific use case, and needs updating to generalize");
+  const historySnapshot = await action.doc.collection("History").get();
+  const historyDocs = [...historySnapshot.docs]
+    .sort((a, b) => a.data().created.toMillis() - b.data().created.toMillis());
+
+  // Find the last markComplete transition
+  const markCompleteIndex = historyDocs
+    .map((d, i) => ({ type: d.data().type, i }))
+    .filter(d => d.type === "markComplete")
+    .at(-1)?.i;
+  if (markCompleteIndex === undefined) {
+    throw new Error("No markComplete transition found in history; cannot revert");
+  }
+
+  // Remove the markComplete transition so the action is no longer complete
+  await historyDocs[markCompleteIndex].ref.delete();
+
+  // Inject a waitETransfer transition with the returned error.
+  // The state machine will be in eTransferComplete and route through handleWaitError.
+  await storeTransition(action.doc, {
+    type: "waitETransfer",
+    created: DateTime.now(),
+    date: returnDate,
+    error: "etransfer: returned",
+  });
+
+  // Re-add the action to the incomplete list so the processor will pick it up
+  const incompleteRef = getFirestore().collection(action.type).doc();
+  await incompleteRef.set({ ref: action.doc as any });
+}
+
+async function checkProceed() {
   const answer = await new Promise<string>(resolve => {
     process.stdout.write(`Proceed? (y/n) `);
     process.stdin.once('data', data => resolve(data.toString().trim().toLowerCase()));
   });
   if (answer !== 'y') {
     console.log("Skipped.");
-    continue;
+    process.stdin.destroy();
+    process.exit(0);
   }
-
-  const tx = await contract.revertTransfer(t.from, t.to, amount, Date.now());
-  const receipt = await tx.wait();
-  console.log("Reverted:", receipt?.hash);
-
-  const balanceFromAfter = await contract.balanceOf(t.from);
-  const balanceToAfter = await contract.balanceOf(t.to);
-  console.log(`  From balance: ${balanceFrom} -> ${balanceFromAfter}`);
-  console.log(`  To balance:   ${balanceTo} -> ${balanceToAfter}`);
 }
 
-process.stdin.destroy();
+
+async function getUserAction(user: string, hash: string) {
+  const allEntries = await getActionsForAddress(user, "Sell");
+  const matching = allEntries.filter(action => 
+    action.history.filter(h => h.hash == hash).length > 0
+  );
+  if (matching.length !== 1) {
+    throw new Error(`Expected exactly one action for hash ${hash}, got ${matching.length}`);
+  }
+  return matching[0];
+}
+
+async function getUserAddress(hash: string) {
+  // First, get the tx receipt for the action
+  const tcCore = await ContractCore.get();
+
+  const provider = tcCore.runner?.provider;
+  if (!provider) {
+    throw new Error("No provider connected");
+  }
+  const txReceipt = await provider.getTransactionReceipt(hash);
+  if (!txReceipt) {
+    throw new Error(`Transaction not found: ${hash}`);
+  }
+
+  const exactTransfer = txReceipt.logs
+    .map(log => {
+      try { return tcCore.interface.parseLog(log); }
+      catch { return null; }
+    })
+    .find(p => p?.name === "ExactTransfer");
+
+  if (!exactTransfer) {
+    throw new Error(`No ExactTransfer event found in transaction ${hash}`);
+  }
+  
+  return exactTransfer.args.from as string;
+}
+
+await init({ service: "BrokerServiceAccount" });
+
+await main();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account history now shows **cost basis** and **profit** alongside each transaction.
* **Bug Fixes**
  * CAD balances are now consistently calculated from the derived FX rate, with clearer handling when an FX rate isn’t available.
* **Improvements**
  * Updated the **e-Transfer revert** utility to use broker history keyed by transaction hash and revert date, simplifying revert handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->