### PR TITLE
tweak 2FA detection to rely on prior section being login, not current.

### DIFF
--- a/apps/harvester/src/Harvester/replay/errorHandling/index.test.ts
+++ b/apps/harvester/src/Harvester/replay/errorHandling/index.test.ts
@@ -11,7 +11,7 @@ const navToAccounts = { type: 'navigation', id: 'nav-accounts', timestamp: 5, to
 it('finds the last interaction when the target event is an interaction', () => {
   const events = [navToLogin, loginInput, loginClick, balanceValue];
   const last = findLastInteraction(events, balanceValue);
-  expect(last).toBe(balanceValue);
+  expect(last).toBe(loginClick);
 });
 
 it('finds the previous interaction when the target event is not an interaction', () => {

--- a/apps/harvester/src/Harvester/replay/errorHandling/index.test.ts
+++ b/apps/harvester/src/Harvester/replay/errorHandling/index.test.ts
@@ -1,0 +1,34 @@
+import { findLastInteraction } from ".";
+
+const zeroCoords = { top: 0, left: 0, centerY: 0, height: 0, width: 0 };
+
+const navToLogin = { type: 'navigation', id: 'nav-login', timestamp: 1, to: 'https://example.com/login' } as any;
+const loginInput = { type: 'input', id: 'input-user', timestamp: 2, eventName: 'username', value: 'user', valueChange: true, tagName: 'INPUT', role: null, selector: 'input#user', coords: zeroCoords, label: 'User', text: '' } as any;
+const loginClick = { type: 'click', id: 'click-login', timestamp: 3, eventName: 'clicked', clickX: 0, clickY: 0, tagName: 'BUTTON', role: null, selector: 'button#login', coords: zeroCoords, label: '', text: 'Log in' } as any;
+const balanceValue = { type: 'value', id: 'value-balance', timestamp: 4, eventName: 'balance', tagName: 'SPAN', role: null, selector: 'span#balance', coords: zeroCoords, label: '', text: '$100.00' } as any;
+const navToAccounts = { type: 'navigation', id: 'nav-accounts', timestamp: 5, to: 'https://example.com/accounts' } as any;
+
+it('finds the last interaction when the target event is an interaction', () => {
+  const events = [navToLogin, loginInput, loginClick, balanceValue];
+  const last = findLastInteraction(events, balanceValue);
+  expect(last).toBe(balanceValue);
+});
+
+it('finds the previous interaction when the target event is not an interaction', () => {
+  const events = [navToLogin, loginInput, loginClick, balanceValue, navToAccounts];
+  const last = findLastInteraction(events, navToAccounts);
+  expect(last).toBe(balanceValue);
+});
+
+it('returns undefined when no interaction exists before the target event', () => {
+  const events = [navToLogin, navToAccounts];
+  const last = findLastInteraction(events, navToAccounts);
+  expect(last).toBeUndefined();
+});
+
+it('returns undefined when the target event is not in the array', () => {
+  const events = [navToLogin, loginInput];
+  const orphan = { ...loginClick, id: 'unknown' };
+  const last = findLastInteraction(events, orphan as any);
+  expect(last).toBeUndefined();
+});

--- a/apps/harvester/src/Harvester/replay/errorHandling/index.ts
+++ b/apps/harvester/src/Harvester/replay/errorHandling/index.ts
@@ -88,10 +88,14 @@ export async function replayErrorHandling({replay, err, event}: ReplayErrorParam
 
 
 export function findLastInteraction(events: AnyEvent[], event: AnyEvent): AnyEvent | undefined {
+  if (!event.id) {
+    log.warn("Event has no ID, cannot find last interaction");
+    return undefined
+  }
   let index = events.findIndex(e => e.id == event.id);
   if (index < 0) {
     log.warn({id: event.id}, "Could not find event {id} in events array");
     return undefined;
   }
-  return events.slice(0, index + 1).findLast(isInteractionEvent);
+  return events.slice(0, index).findLast(isInteractionEvent);
 }

--- a/apps/harvester/src/Harvester/replay/errorHandling/index.ts
+++ b/apps/harvester/src/Harvester/replay/errorHandling/index.ts
@@ -1,12 +1,12 @@
 import { maybeCloseModal } from "@thecointech/scraper-agent/modal";
 import { notify, notifyError } from "@/notify";
 import { TimeoutError } from "puppeteer";
-import type { ReplayErrorParams } from "@thecointech/scraper";
+import type { AnyEvent, ReplayErrorParams } from "@thecointech/scraper";
 import type { EventSection } from "@thecointech/scraper-agent/types";
 import { ElementNotFoundError } from "@thecointech/scraper";
 import { log } from "@thecointech/logging";
 import { handleTwoFA } from "./twofa";
-import { isPageInSection, findSectionByEvent, findSectionByName } from "./utils";
+import { isPageInSection, findSectionByEvent, findSectionByName, isInteractionEvent } from "./utils";
 
 export async function replayErrorHandling({replay, err, event}: ReplayErrorParams, root: EventSection): Promise<number|undefined> {
   const section = findSectionByEvent(event, root);
@@ -24,11 +24,14 @@ export async function replayErrorHandling({replay, err, event}: ReplayErrorParam
   // - Unknown redirect
   const { page, events } = replay;
 
+  const lastEvent = findLastInteraction(events, event);
+  log.info({section: lastEvent?.section ?? "NOT FOUND"}, "Last interaction section: {section}");
+
   // 2FA can interrupt login: either an element is not found because we
   // landed on the TwoFA page, or a navigation out of Login times out.
-  // The only possible sectins are Login (if the page pops over the current page)
-  // or AccountsSummary (it is the only legal next section)
-  if (section.section === "Login" || section.section === "AccountsSummary") {
+  // If our last interaction was within a login, (or undefined,
+  // as a failsafe) check for 2FA page and handle if found.
+  if (!lastEvent?.section || lastEvent.section === "Login") {
     if (err instanceof ElementNotFoundError || err instanceof TimeoutError) {
       const twoFaSection = findSectionByName("TwoFA", root);
       if (!twoFaSection) {
@@ -81,4 +84,14 @@ export async function replayErrorHandling({replay, err, event}: ReplayErrorParam
 
   // No way to handle this error
   return undefined;
+}
+
+
+export function findLastInteraction(events: AnyEvent[], event: AnyEvent): AnyEvent | undefined {
+  let index = events.findIndex(e => e.id == event.id);
+  if (index < 0) {
+    log.warn({id: event.id}, "Could not find event {id} in events array");
+    return undefined;
+  }
+  return events.slice(0, index + 1).findLast(isInteractionEvent);
 }

--- a/apps/harvester/src/Harvester/replay/errorHandling/twofa.ts
+++ b/apps/harvester/src/Harvester/replay/errorHandling/twofa.ts
@@ -13,7 +13,11 @@ export async function handleTwoFA(page: Page, events: AnyEvent[], root: EventSec
     await attemptEnterTwoFA(replay, twoFaSection);
     // Our assumption is that if we do not throw, we should
     // be able to continue with the rest of the replay.
-    const success = await isPageInSection(page, root, "AccountsSummary");
+    // The timeout is set large because in this pathway may not include the
+    // regular waiting mechanisms - eg in recording, the vLLM helps watch
+    // for loading to complete, and in replay the system waits for the elements
+    // to become visible, so here we need to wait too.
+    const success = await isPageInSection(page, root, "AccountsSummary", 60_000);
     if (!success) {
       throw new Error("Attempted to enter 2FA, but failed to enter AccountsSummary");
     }

--- a/apps/harvester/src/Harvester/replay/errorHandling/utils.ts
+++ b/apps/harvester/src/Harvester/replay/errorHandling/utils.ts
@@ -40,7 +40,7 @@ export function findSectionByName(search: SectionName, section: EventSection) : 
   return null;
 }
 
-export async function isPageInSection(page: Page, root: EventSection, sectionName: SectionName) {
+export async function isPageInSection(page: Page, root: EventSection, sectionName: SectionName, timeout=1000) {
   const section = findSectionByName(sectionName, root);
   if (section) {
     // The easiest way to tell is to search for the first element
@@ -52,7 +52,7 @@ export async function isPageInSection(page: Page, root: EventSection, sectionNam
       try {
         const matched = await getElementForEvent({
           page,
-          timeout: 1000,
+          timeout,
           event: {
             ...firstElement,
             eventName: "isIn" + sectionName,

--- a/apps/harvester/src/Harvester/replay/errorHandling/utils.ts
+++ b/apps/harvester/src/Harvester/replay/errorHandling/utils.ts
@@ -1,4 +1,4 @@
-import type { AnyEvent } from "@thecointech/scraper";
+import type { AnyEvent, ClickEvent, ValueEvent, InputEvent } from "@thecointech/scraper";
 import type { EventSection, SectionName } from "@thecointech/scraper-agent/types";
 import type { Page } from "puppeteer";
 import { getElementForEvent } from "@thecointech/scraper/elements";
@@ -47,7 +47,7 @@ export async function isPageInSection(page: Page, root: EventSection, sectionNam
     const events = flatten(section, [sectionName]);
 
     // Search for the first page interaction we do in the section
-    const firstElement = events.find(e => (e.type === "input" || e.type === "click" || e.type == "value"));
+    const firstElement = events.find(isInteractionEvent);
     if (firstElement) {
       try {
         const matched = await getElementForEvent({
@@ -69,4 +69,9 @@ export async function isPageInSection(page: Page, root: EventSection, sectionNam
     log.error(`Section ${sectionName} not found in root section, cannot determine if page is in section`);
   }
   return null;
+}
+
+
+export function isInteractionEvent(event: AnyEvent): event is InputEvent | ClickEvent | ValueEvent {
+  return event.type === "input" || event.type === "click" || event.type === "value";
 }


### PR DESCRIPTION
Resolves #917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay recovery by using the most recent prior user interaction to drive error handling decisions.
  * Strengthened 2FA handling by safely falling back when interaction history is unavailable and by waiting up to 60 seconds for the Accounts Summary page.
* **Tests**
  * Added Jest coverage for locating the latest interaction, including missing events and scenarios with no prior interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->