### PR TITLE
fix use node:scrypt when - fixes hang decrypting in docker

### DIFF
--- a/libs/async/mocks/async_mocked.ts
+++ b/libs/async/mocks/async_mocked.ts
@@ -3,4 +3,8 @@ export function sleep() {
   return new Promise(resolve => setTimeout(resolve, 100));
 }
 
+export function withTimeout<T>(promise: Promise<T>, _ms: number, _label: string): Promise<T> {
+  return promise;
+}
+
 export { Mutex } from 'async-mutex';

--- a/libs/async/src/index.ts
+++ b/libs/async/src/index.ts
@@ -3,4 +3,13 @@ export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    ),
+  ]);
+}
+
 export { Mutex } from 'async-mutex';

--- a/libs/async/src/index.ts
+++ b/libs/async/src/index.ts
@@ -4,12 +4,16 @@ export function sleep(ms: number) {
 }
 
 export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
-    ),
-  ]);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms
+    );
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout !== undefined) clearTimeout(timeout);
+  });
 }
 
 export { Mutex } from 'async-mutex';

--- a/libs/signers/package.json
+++ b/libs/signers/package.json
@@ -59,7 +59,8 @@
     "@thecointech/electron-signer": "^0.6.6-test.0",
     "@thecointech/ethers-provider": "^0.6.6-test.0",
     "@thecointech/logging": "^0.6.6-test.0",
-    "@thecointech/secrets": "^0.6.6-test.0"
+    "@thecointech/secrets": "^0.6.6-test.0",
+    "@thecointech/utilities": "^0.6.6-test.0"
   },
   "devDependencies": {
     "@thecointech/electron-utils": "^0.6.6-test.0"

--- a/libs/signers/src/fromDisk.ts
+++ b/libs/signers/src/fromDisk.ts
@@ -5,13 +5,50 @@ import { join } from 'path';
 import type { AccountName } from './names';
 import { getProvider } from '@thecointech/ethers-provider';
 import { getSecret } from '@thecointech/secrets/live';
+import { withTimeout } from '@thecointech/async';
+import { log } from '@thecointech/logging';
+import { scrypt as nodeScrypt } from 'node:crypto';
+// @ts-expect-error
+import { scrypt } from 'ethers/crypto';
+
+type ScryptProgressCallback = (percent: number) => void;
+
+// Use Node's native scrypt instead of the pure-JS implementation to avoid
+// extremely slow decryption inside Docker / resource-constrained environments.
+scrypt.register(async (
+  passwd: Uint8Array,
+  salt: Uint8Array,
+  N: number,
+  r: number,
+  p: number,
+  dkLen: number,
+  progress?: ScryptProgressCallback
+): Promise<Uint8Array> => {
+  if (progress) progress(0);
+  const derived = await new Promise<Uint8Array>((resolve, reject) => {
+    const maxmem = Math.max(128 * N * r * p * 2, 64 * 1024 * 1024);
+    nodeScrypt(passwd, salt, dkLen, { N, r, p, maxmem }, (err, key) => {
+      if (err) reject(err);
+      else resolve(Uint8Array.from(key));
+    });
+  });
+  if (progress) progress(1);
+  return derived;
+});
 
 export async function loadFromDisk(name: AccountName, callback?: ProgressCallback) {
+  log.debug({ name }, 'Signer {name}: loading wallet from disk');
   const encrypted = loadEncrypted(name);
   const key = await getPassword(name);
-  const wallet = await Wallet.fromEncryptedJson(encrypted, key, callback);
-  return wallet.connect(await getProvider());
+  const wallet = await withTimeout(
+    Wallet.fromEncryptedJson(encrypted, key, callback),
+    60_000,
+    `decrypt signer ${name}`
+  );
+  const provider = await getProvider();
+  return wallet.connect(provider);
 }
+
 // or from file system if name is a path.
 function loadEncrypted(name: AccountName) {
 

--- a/libs/signers/src/fromDisk.ts
+++ b/libs/signers/src/fromDisk.ts
@@ -1,50 +1,20 @@
 import type { ProgressCallback } from 'ethers';
-import { Wallet } from "ethers";
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import type { AccountName } from './names';
 import { getProvider } from '@thecointech/ethers-provider';
 import { getSecret } from '@thecointech/secrets/live';
-import { withTimeout } from '@thecointech/async';
+import { decryptWallet } from '@thecointech/utilities/wallet';
 import { log } from '@thecointech/logging';
-import { scrypt as nodeScrypt } from 'node:crypto';
-// @ts-expect-error
-import { scrypt } from 'ethers/crypto';
-
-type ScryptProgressCallback = (percent: number) => void;
-
-// Use Node's native scrypt instead of the pure-JS implementation to avoid
-// extremely slow decryption inside Docker / resource-constrained environments.
-scrypt.register(async (
-  passwd: Uint8Array,
-  salt: Uint8Array,
-  N: number,
-  r: number,
-  p: number,
-  dkLen: number,
-  progress?: ScryptProgressCallback
-): Promise<Uint8Array> => {
-  if (progress) progress(0);
-  const derived = await new Promise<Uint8Array>((resolve, reject) => {
-    const maxmem = Math.max(128 * N * r * p * 2, 64 * 1024 * 1024);
-    nodeScrypt(passwd, salt, dkLen, { N, r, p, maxmem }, (err, key) => {
-      if (err) reject(err);
-      else resolve(Uint8Array.from(key));
-    });
-  });
-  if (progress) progress(1);
-  return derived;
-});
 
 export async function loadFromDisk(name: AccountName, callback?: ProgressCallback) {
   log.debug({ name }, 'Signer {name}: loading wallet from disk');
   const encrypted = loadEncrypted(name);
   const key = await getPassword(name);
-  const wallet = await withTimeout(
-    Wallet.fromEncryptedJson(encrypted, key, callback),
-    60_000,
-    `decrypt signer ${name}`
-  );
+  const wallet = await decryptWallet(encrypted, key, {
+    timeoutMs: 60_000,
+    onProgress: callback,
+  });
   const provider = await getProvider();
   return wallet.connect(provider);
 }

--- a/libs/tx-gmail/src/initialize.ts
+++ b/libs/tx-gmail/src/initialize.ts
@@ -2,6 +2,7 @@ import { getAuthClient } from './auth';
 import { initializeApi } from './fetch';
 import { getNewTokens } from './token';
 import { log } from '@thecointech/logging';
+import { withTimeout } from '@thecointech/async';
 
 
 export async function initialize(token?: string) {
@@ -31,7 +32,11 @@ async function getAuth(token?: string) {
       if (credentials.refresh_token) {
         // validate that the token is still value by refreshing it
         try {
-          const refreshed = await client.refreshAccessToken();
+          const refreshed = await withTimeout(
+            client.refreshAccessToken(), 
+            30_000, 
+            'refreshAccessToken'
+          );
           return { client, credentials: refreshed.credentials };
         }
         catch (err) {

--- a/libs/utils-ts/package.json
+++ b/libs/utils-ts/package.json
@@ -22,15 +22,18 @@
     "prepublishOnly": "yarn run -T rimraf ./build/.buildinfo",
     "build": "run -T tsc -b",
     "clean": "run -T rimraf ./build && run -T rimraf ./coverage",
+    "pretest": "yarn build",
     "test": "run :jest",
     "test:summary": "jest --coverage > ./coverage/summary.txt"
   },
   "files": [
     "build/**/*"
   ],
-  "main": "./build/index.js",
   "exports": {
     ".": "./build/index.js",
+    "./wallet": {
+      "node": "./build/wallet-node.js"
+    },
     "./*": "./build/*.js"
   },
   "types": "./build/index.d.ts",
@@ -39,6 +42,9 @@
       "build/index.d.ts": [
         "build/index.d.ts"
       ],
+      "wallet": [
+        "build/wallet-node.d.ts"
+      ],
       "*": [
         "build/*.d.ts",
         "build/*/index.d.ts"
@@ -46,6 +52,7 @@
     }
   },
   "dependencies": {
+    "@thecointech/async": "^0.6.6-test.0",
     "@thecointech/logging": "^0.6.6-test.0",
     "@thecointech/secrets": "^0.6.6-test.0",
     "base32": "^0.0.7",

--- a/libs/utils-ts/src/wallet-node.ts
+++ b/libs/utils-ts/src/wallet-node.ts
@@ -1,0 +1,88 @@
+import { Worker } from 'node:worker_threads';
+import { withTimeout } from '@thecointech/async';
+import type { DecryptWalletOptions, WalletMessage } from './wallet.js';
+import { HDNodeWallet, Wallet } from 'ethers';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+// The worker is loaded from the compiled build output. Run `yarn build` (or
+// `yarn test`, which has `pretest: yarn build`) before running tests.
+// (this is necessary to allow both built & un-built code -eg jest - to work)
+const workerPath = new URL('../build/wallet.worker.js', import.meta.url);
+
+export async function decryptWallet(
+  encryptedJson: string,
+  password: string,
+  options: DecryptWalletOptions = {}
+): Promise<HDNodeWallet|Wallet> {
+  const { signal, timeoutMs = DEFAULT_TIMEOUT_MS, onProgress } = options;
+
+  if (signal?.aborted) {
+    throw new Error('Wallet decrypt aborted');
+  }
+
+  const worker = new Worker(workerPath);
+  let settled = false;
+
+  const cleanupSignal = (handler: () => void) => {
+    signal?.removeEventListener('abort', handler);
+  };
+
+  try {
+    return await withTimeout(
+      new Promise<HDNodeWallet|Wallet>((resolve, reject) => {
+        const abortHandler = () => {
+          if (!settled) {
+            settled = true;
+            reject(new Error('Wallet decrypt aborted'));
+          }
+          void worker.terminate();
+        };
+        signal?.addEventListener('abort', abortHandler, { once: true });
+
+        worker.on("message", (msg: WalletMessage) => {
+          if (msg.type === 'progress') {
+            onProgress?.(msg.progress);
+            return;
+          }
+          if (settled) return;
+          settled = true;
+          cleanupSignal(abortHandler);
+          switch (msg.type) {
+            case 'error':
+              reject(new Error(msg.error));
+              break;
+            case 'mnemonic':
+              resolve(HDNodeWallet.fromPhrase(msg.phrase, undefined, msg.path ?? undefined));
+              break;
+            case 'privateKey':
+              resolve(new Wallet(msg.privateKey));
+              break;
+            default:
+              reject(new Error('Wallet decrypt worker returned an invalid result'));
+          }
+        });
+
+        worker.on('error', (err) => {
+          if (settled) return;
+          settled = true;
+          cleanupSignal(abortHandler);
+          reject(err);
+        });
+
+        worker.on('exit', (code) => {
+          if (settled) return;
+          settled = true;
+          cleanupSignal(abortHandler);
+          reject(new Error(`Wallet decrypt worker exited unexpectedly with code ${code}`));
+        });
+
+        worker.postMessage({ encryptedJson, password });
+      }),
+      timeoutMs,
+      'decrypt wallet'
+    );
+  } finally {
+    await worker.terminate();
+  }
+}

--- a/libs/utils-ts/src/wallet-node.ts
+++ b/libs/utils-ts/src/wallet-node.ts
@@ -41,8 +41,15 @@ export async function decryptWallet(
         signal?.addEventListener('abort', abortHandler, { once: true });
 
         worker.on("message", (msg: WalletMessage) => {
+          if (settled) return;
           if (msg.type === 'progress') {
-            onProgress?.(msg.progress);
+            try {
+              onProgress?.(msg.progress);
+            } catch (err) {
+              settled = true;
+              cleanupSignal(abortHandler);
+              reject(err);
+            }
             return;
           }
           if (settled) return;

--- a/libs/utils-ts/src/wallet.test.ts
+++ b/libs/utils-ts/src/wallet.test.ts
@@ -1,0 +1,10 @@
+import { Wallet } from "ethers";
+import { decryptWallet } from "./wallet-node";
+import { it, expect } from "@jest/globals";
+
+it("decryptWallet should work", async () => {
+  const wallet = Wallet.createRandom()
+  const encrypted = wallet.encryptSync("test")
+  const decrypted = await decryptWallet(encrypted, "test")
+  expect(decrypted.address).toEqual(wallet.address)
+})

--- a/libs/utils-ts/src/wallet.ts
+++ b/libs/utils-ts/src/wallet.ts
@@ -1,0 +1,28 @@
+export interface DecryptWalletOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  onProgress?: (progress: number) => void;
+}
+
+type ProgressMessage = {
+  type: 'progress';
+  progress: number;
+}
+
+type MnemonicResult = {
+  type: 'mnemonic';
+  phrase: string;
+  path: string | null;
+}
+
+type PrivateKeyResult = {
+  type: 'privateKey';
+  privateKey: string;
+}
+
+type ErrorMessage = {
+  type: 'error';
+  error: string;
+}
+
+export type WalletMessage = ProgressMessage | MnemonicResult | PrivateKeyResult | ErrorMessage;

--- a/libs/utils-ts/src/wallet.worker.ts
+++ b/libs/utils-ts/src/wallet.worker.ts
@@ -1,0 +1,53 @@
+import { parentPort } from 'node:worker_threads';
+import { Wallet } from 'ethers';
+import { scrypt as nodeScrypt } from 'node:crypto';
+// @ts-expect-error this will be fixed when we switch to a newer moduleresolution
+import { scrypt } from 'ethers/crypto';
+import type { WalletMessage } from './wallet';
+
+interface DecryptMessage {
+  encryptedJson: string;
+  password: string;
+}
+
+const postMessage = (msg: WalletMessage) => {
+  parentPort?.postMessage(msg);
+};
+
+type ScryptProgressCallback = (percent: number) => void;
+
+// Use Node's native scrypt instead of the pure-JS implementation to avoid
+// extremely slow decryption inside Docker / resource-constrained environments.
+scrypt.register(async (
+  passwd: Uint8Array,
+  salt: Uint8Array,
+  N: number,
+  r: number,
+  p: number,
+  dkLen: number,
+  _progress?: ScryptProgressCallback
+): Promise<Uint8Array> => {
+  postMessage({ type: 'progress', progress: 0 });
+  const derived = await new Promise<Uint8Array>((resolve, reject) => {
+    const maxmem = Math.max(128 * N * r * p * 2, 64 * 1024 * 1024);
+    nodeScrypt(passwd, salt, dkLen, { N, r, p, maxmem }, (err, key) => {
+      if (err) reject(err);
+      else resolve(Uint8Array.from(key));
+    });
+  });
+  postMessage({ type: 'progress', progress: 1 });
+  return derived;
+});
+
+parentPort?.on("message", async ({ encryptedJson, password }: DecryptMessage) => {
+  try {
+    const wallet = await Wallet.fromEncryptedJson(encryptedJson, password);
+    if ("mnemonic" in wallet && wallet.mnemonic) {
+      postMessage({ type: 'mnemonic', phrase: wallet.mnemonic.phrase, path: wallet.path })
+    } else {
+      postMessage({ type: 'privateKey', privateKey: wallet.privateKey })
+    }
+  } catch (err: any) {
+    postMessage({ type: 'error', error: err.message ?? String(err) });
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12088,6 +12088,7 @@ __metadata:
     "@thecointech/ethers-provider": "npm:^0.6.6-test.0"
     "@thecointech/logging": "npm:^0.6.6-test.0"
     "@thecointech/secrets": "npm:^0.6.6-test.0"
+    "@thecointech/utilities": "npm:^0.6.6-test.0"
   languageName: unknown
   linkType: soft
 
@@ -12513,6 +12514,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@thecointech/utilities@workspace:libs/utils-ts"
   dependencies:
+    "@thecointech/async": "npm:^0.6.6-test.0"
     "@thecointech/jestutils": "npm:^0.6.6-test.0"
     "@thecointech/logging": "npm:^0.6.6-test.0"
     "@thecointech/secrets": "npm:^0.6.6-test.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for asynchronous operations, including wallet decryption and Gmail token refresh.
  * Improved encrypted wallet loading with progress updates, cancellation support, and native background processing.
* **Bug Fixes**
  * Added safeguards to prevent wallet decryption and Gmail token refresh operations from hanging indefinitely.
  * Wallets now connect to their provider after loading successfully.
  * Improved handling of wallet decryption errors and invalid results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->